### PR TITLE
[BOT] refactor(rename): Game audio chunk

### DIFF
--- a/2006Scape Client/src/main/java/Class56_Sub1_Sub1.java
+++ b/2006Scape Client/src/main/java/Class56_Sub1_Sub1.java
@@ -51,7 +51,7 @@ final class Class56_Sub1_Sub1 extends Class56_Sub1 implements Receiver
 		    aSequencer1851.open();
 		    method838(-1L);
 		} catch (Exception exception) {
-		    Game.method790();
+		    Game.shutdownMidiPlayer();
 		}
     }
     


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre‑flight Checklist

| Item | Status |
| --- | --- |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes | ❌ |
| ≥ 80 % coverage on touched lines | ❌ |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why
Renames a subset of obfuscated audio management identifiers in `Game.java` to clearer names.

## 🗂️ Detailed Changes
- updated `Game` music management methods and fields with descriptive names
- adjusted `Class56_Sub1_Sub1` constructor to call the renamed cleanup method

## ♻️ Rename‑Specific Fields

| Old Identifier | New Identifier |
| -------------- | -------------- |
| aClass56_749 | midiPlayer |
| anInt720 | musicDelay |
| musicVolume2 | nextTrackVolume |
| anInt478 | currentVolume |
| aByteArray347 | queuedTrackData |
| anInt155 | fadePosition |
| anInt2200 | fadeStep |
| anInt1478 | queuedVolume |
| aBoolean475 | loopQueuedTrack |
| anInt116 | queuedTrackDelay |
| aBoolean995 | trackRequest |
| anInt139 | currentTrackId |
| musicVolume | musicVolumeSetting |
| fetchMusic | fetchTrack |
| method790 | shutdownMidiPlayer |
| method900 | setMidiVolumeDirect |
| method55 | stopMusic |
| method891 | stopCurrentTrack |
| method58 | queueTrackWithDelay |
| method56 | queueTrackImmediate |
| method49 | processMusicQueue |
| method1004 | logVolumeScale |
| method853 | playTrack |
| method899 | queueTrackFade |
| method684 | fadeQueuedTrack |
| method368 | updateMidi |

- **Batch**: 1/1
- **Revert command**: `git revert -m 1 b26ec05c`

## 📊 Diff Stat
```text
$(git diff --stat origin/main...HEAD)
```

## 🧪 Integration‑Test Log
N/A – Maven unavailable in environment.

## 📝 Rollback Plan
If this PR causes a failure on `main`, run the revert command above.


------
https://chatgpt.com/codex/tasks/task_e_686134dfa988832bb7d7a1e2a382e0ac