### PR TITLE
[BOT] feat(item): add Lime Whip weapon

### DIFF
--- a/2006Scape Client/src/main/java/ItemDef.java
+++ b/2006Scape Client/src/main/java/ItemDef.java
@@ -2021,11 +2021,23 @@ public final class ItemDef {
 			itemDef.anInt165 = 18914;
 			itemDef.anInt200 = 18967;
 			itemDef.name = "Quest hood";
-			itemDef.description = "Quest skillcape hood.".getBytes();
-			break;
-			}
-		return itemDef;
-	}
+                        itemDef.description = "Quest skillcape hood.".getBytes();
+                        break;
+
+                case 16022:
+                        itemDef.actions = new String[5];
+                        itemDef.actions[1] = "Wield";
+                        itemDef.modelID = 5412;
+                        itemDef.modelZoom = 840;
+                        itemDef.name = "Lime whip";
+                        itemDef.modifiedModelColors = new int[1];
+                        itemDef.originalModelColors = new int[1];
+                        itemDef.modifiedModelColors[0] = 17350;
+                        itemDef.originalModelColors[0] = 0;
+                        break;
+                        }
+                return itemDef;
+        }
 
 	private void toNote() {
 		ItemDef itemDef = forID(certTemplateID);

--- a/2006Scape Server/data/cfg/ItemDefinitions.json
+++ b/2006Scape Server/data/cfg/ItemDefinitions.json
@@ -21021,5 +21021,14 @@
    {
       "id":7951,
       "weight":9.0
+   },
+   {
+      "id":16022,
+      "weight":45.0,
+      "bonuses":{
+         "attackSlash":90,
+         "strengthBonus":90,
+         "prayerBonus":1
+      }
    }
 ]

--- a/2006Scape Server/src/main/java/com/rs2/game/content/StaticItemList.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/StaticItemList.java
@@ -4160,8 +4160,9 @@ public class StaticItemList {
 	public static final int NECHRYAEL = 4148;
 	public static final int ABYSSAL_DEMON = 4149;
 	public static final int BROAD_ARROWS = 4150;
-	public static final int ABYSSAL_WHIP = 4151;
-	public static final int ABYSSAL_WHIP_4152 = 4152;
+       public static final int ABYSSAL_WHIP = 4151;
+       public static final int LIME_WHIP = 16022;
+       public static final int ABYSSAL_WHIP_4152 = 4152;
 	public static final int GRANITE_MAUL = 4153;
 	public static final int GRANITE_MAUL_4154 = 4154;
 	public static final int ENCHANTED_GEM = 4155;

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/Specials.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/Specials.java
@@ -24,7 +24,8 @@ public class Specials {
 		// ItemName(ItemId, SpecDamage, SpecAccuracy, SpecAmount, Anim, GFX0,
 		// GFX100, DoubleHit, SsSpec, SpecEffect)
 
-		ABYSSAL_WHIP(StaticItemList.ABYSSAL_WHIP, 1, 1.25, 5, 1658, 341, -1, false, 0),
+                ABYSSAL_WHIP(StaticItemList.ABYSSAL_WHIP, 1, 1.25, 5, 1658, 341, -1, false, 0),
+                LIME_WHIP(StaticItemList.LIME_WHIP, 1, 1.25, 5, 1658, 341, -1, false, 0),
 		DRAGON_DAGGER(StaticItemList.DRAGON_DAGGER, 1.15, 1.25, 2.5, 1062, -1, 252, true, 0),
 		DRAGON_DAGGER_P(StaticItemList.DRAGON_DAGGERP, 1.15, 1.25, 2.5, 1062, -1, 252, true, 0),
 		DRAGON_DAGGER_PP(StaticItemList.DRAGON_DAGGERS, 1.15, 1.25, 2.5, 1062, -1, 252, true, 0),
@@ -285,13 +286,14 @@ public class Specials {
 		}
 		break;
 
-		case 48023:
-			if (player2.playerEquipment[player2.playerWeapon] == StaticItemList.ABYSSAL_WHIP) {
-				player2.specBarId = 12335;
-				player2.usingSpecial = !player2.usingSpecial;
-				player2.getItemAssistant().updateSpecialBar();
-			}
-			break;
+                case 48023:
+                        if (player2.playerEquipment[player2.playerWeapon] == StaticItemList.ABYSSAL_WHIP
+                                        || player2.playerEquipment[player2.playerWeapon] == StaticItemList.LIME_WHIP) {
+                                player2.specBarId = 12335;
+                                player2.usingSpecial = !player2.usingSpecial;
+                                player2.getItemAssistant().updateSpecialBar();
+                        }
+                        break;
 
 		case 29138:
 			if (player2.playerEquipment[player2.playerWeapon] == StaticItemList.DRAGON_DAGGER || player2.playerEquipment[player2.playerWeapon] == StaticItemList.DRAGON_DAGGERP

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/melee/MeleeData.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/melee/MeleeData.java
@@ -277,6 +277,7 @@ public class MeleeData {
 
         switch (c.playerEquipment[c.playerWeapon]) {
             case 4151:
+            case StaticItemList.LIME_WHIP:
                 c.playerStandIndex = 1832;
                 c.playerWalkIndex = 1660;
                 c.playerRunIndex = 1661;
@@ -404,6 +405,7 @@ public class MeleeData {
             case 4734: // karil
                 return 2075;
             case 4151:
+            case StaticItemList.LIME_WHIP:
                 return 1658;
             case 6528:
                 return 2661;
@@ -440,6 +442,7 @@ public class MeleeData {
                 return 1666;
 
             case 4151:
+            case StaticItemList.LIME_WHIP:
                 return 1659;
 
             case 11694:

--- a/2006Scape Server/src/main/java/com/rs2/game/content/music/sound/CombatSounds.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/music/sound/CombatSounds.java
@@ -414,16 +414,17 @@ public class CombatSounds {
 					|| c.playerEquipment[c.playerWeapon] == 2748) { // Godswords
 				return 390;
 			}
-			if (c.playerEquipment[c.playerWeapon] == 4151) {
-				return 1080;
-			}
+                        if (c.playerEquipment[c.playerWeapon] == 4151
+                                        || c.playerEquipment[c.playerWeapon] == StaticItemList.LIME_WHIP) {
+                                return 1080;
+                        }
 		}
 		return 398;
 	}
 
 	public static int specialSounds(int id) {
-		if (id == 4151) {// whip
-			return 1081;
+                if (id == 4151 || id == StaticItemList.LIME_WHIP) {// whip
+                        return 1081;
 		} else if (id == 5698 || id == 1231 || id == 1215 || id == 5680) {// dds
 			return 385;
 		} else if (id == 1434) {// Mace

--- a/2006Scape Server/src/main/java/com/rs2/game/items/ItemAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/items/ItemAssistant.java
@@ -947,9 +947,10 @@ public class ItemAssistant {
 				player.rangeLevelReq = 61;
 				break;
 
-			case 4151: // if you don't want to use names
-				player.attackLevelReq = 70;
-				return;
+                    case 4151: // if you don't want to use names
+                    case StaticItemList.LIME_WHIP:
+                        player.attackLevelReq = 70;
+                        return;
 
 			case 6724: // seercull
 				player.rangeLevelReq = 60; // idk if that is correct
@@ -1103,10 +1104,11 @@ public class ItemAssistant {
 	public void addSpecialBar(int weapon) {
 		switch (weapon) {
 
-			case 4151: // whip
-				player.getPacketSender().sendHideInterfaceLayer(12323, false);
-				specialAmount(weapon, player.specAmount, 12335);
-				break;
+                case 4151: // whip
+                case StaticItemList.LIME_WHIP:
+                        player.getPacketSender().sendHideInterfaceLayer(12323, false);
+                        specialAmount(weapon, player.specAmount, 12335);
+                        break;
 
 			case 859: // magic bows
 			case 861:


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes             | ❌ |
| ≥ 80 % coverage on touched lines    | ❌ |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Adds a new Lime Whip item mirroring Abyssal Whip behaviour with a small stat boost. The server treats it exactly like a whip and client displays a recoloured model.

## 🗂️ Detailed Changes
- defined `LIME_WHIP` constant and combat logic updates
- extended item definitions JSON with stats for id `16022`
- added client-side case for displaying the Lime Whip model

## 📊 Diff Stat
```text
 7 files changed, 57 insertions(+), 27 deletions(-)
```


------
https://chatgpt.com/codex/tasks/task_e_68624f4d5f60832b91f92c09d261efa6