### PR TITLE
[BOT] refactor(rename): Object3 → TileDecoration

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -10129,7 +10129,7 @@ public class Game extends RSApplet {
 					}
 				}
 				if (j16 == 3) {
-					Object3 class49 = worldController.method299(i7, j4, plane);
+                                        TileDecoration class49 = worldController.method299(i7, j4, plane);
 					if (class49 != null) {
 						class49.aClass30_Sub2_Sub4_814 = new Animable_Sub5(class49.uid >> 14 & 0x7fff, k14, 22, i19, l19, j18, k20, j17, false);
 					}

--- a/2006Scape Client/src/main/java/Ground.java
+++ b/2006Scape Client/src/main/java/Ground.java
@@ -20,7 +20,7 @@ public final class Ground extends Node {
 	public Class40 aClass40_1312;
 	public Object1 obj1;
 	public Object2 obj2;
-	public Object3 obj3;
+        public TileDecoration obj3;
 	public Object4 obj4;
 	int anInt1317;
 	public final Object5[] obj5Array;

--- a/2006Scape Client/src/main/java/TileDecoration.java
+++ b/2006Scape Client/src/main/java/TileDecoration.java
@@ -2,10 +2,9 @@
 // Jad home page: http://www.kpdus.com/jad.html
 // Decompiler options: packimports(3) 
 
-public final class Object3 {
+public final class TileDecoration {
 
-	public Object3() {
-	}
+        public TileDecoration() {}
 
 	int anInt811;
 	int anInt812;

--- a/2006Scape Client/src/main/java/WorldController.java
+++ b/2006Scape Client/src/main/java/WorldController.java
@@ -155,7 +155,7 @@ final class WorldController {
 		if (class30_sub2_sub4 == null) {
 			return;
 		}
-		Object3 class49 = new Object3();
+            TileDecoration class49 = new TileDecoration();
 		class49.aClass30_Sub2_Sub4_814 = class30_sub2_sub4;
 		class49.anInt812 = j1 * 128 + 64;
 		class49.anInt813 = k * 128 + 64;
@@ -482,7 +482,7 @@ final class WorldController {
 		return null;
 	}
 
-	public Object3 method299(int i, int j, int k) {
+    public TileDecoration method299(int i, int j, int k) {
 		Ground class30_sub3 = groundArray[k][j][i];
 		if (class30_sub3 == null || class30_sub3.obj3 == null) {
 			return null;
@@ -584,7 +584,7 @@ final class WorldController {
 							}
 						}
 
-						Object3 class49 = class30_sub3.obj3;
+                                            TileDecoration class49 = class30_sub3.obj3;
 						if (class49 != null && class49.aClass30_Sub2_Sub4_814.aVertexNormalArray1425 != null) {
 							method306(i2, l1, (Model) class49.aClass30_Sub2_Sub4_814, j2);
 							((Model) class49.aClass30_Sub2_Sub4_814).method480(j, k1, k, i, i1);
@@ -1207,7 +1207,7 @@ final class WorldController {
 					}
 				}
 				if (flag1) {
-					Object3 class49 = class30_sub3_1.obj3;
+                                   TileDecoration class49 = class30_sub3_1.obj3;
 					if (class49 != null) {
 						class49.aClass30_Sub2_Sub4_814.method443(0, anInt458, anInt459, anInt460, anInt461, class49.anInt812 - anInt455, class49.anInt811 - anInt456, class49.anInt813 - anInt457, class49.uid);
 					}


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why

Renamed the decompiled class `Object3` to `TileDecoration` for better clarity.

## 🗂️ Detailed Changes
- Renamed file and class
- Updated all references in `Ground`, `WorldController`, and `Game`

## ♻️ Rename-Specific Fields

| Old Identifier | New Identifier |
| -------------- | -------------- |
| Object3        | TileDecoration |

- **Batch**: 
- **Revert command**: `git revert -m 1 a695970f`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java                          | 2 +-
 2006Scape Client/src/main/java/Ground.java                        | 2 +-
 .../src/main/java/{Object3.java => TileDecoration.java}           | 5 ++---
 2006Scape Client/src/main/java/WorldController.java               | 8 ++++----
 4 files changed, 8 insertions(+), 9 deletions(-)
```

## 🧪 Integration-Test Log

Compilation succeeded with warnings. Tests and runtime checks failed due to missing tools.

## 📝 Rollback Plan

If this PR causes failures on `main`, the bot will open a revert PR using the command above.


------
https://chatgpt.com/codex/tasks/task_e_686253054f54832bbf757ab067f38c13