### PR TITLE
[BOT] refactor(rename): DummyClass → CachePlaceholder

### DIFF
--- a/2006Scape Client/src/main/java/CachePlaceholder.java
+++ b/2006Scape Client/src/main/java/CachePlaceholder.java
@@ -2,10 +2,10 @@
 // Jad home page: http://www.kpdus.com/jad.html
 // Decompiler options: packimports(3) 
 
-public final class DummyClass {
+public final class CachePlaceholder {
 
-	public DummyClass() {
+	public CachePlaceholder() {
 	}
 
-	public static DummyClass cache[];
+	public static CachePlaceholder cache[];
 }

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -4793,7 +4793,7 @@ public class Game extends RSApplet {
 		Flo.cache = null;
 		IDK.cache = null;
 		RSInterface.interfaceCache = null;
-		DummyClass.cache = null;
+		CachePlaceholder.cache = null;
 		Animation.anims = null;
 		SpotAnim.cache = null;
 		SpotAnim.aMRUNodes_415 = null;


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item | Status |
| --- | --- |
| `mvn -B verify -o` passes (offline) | ❌ *(tests-all.jar missing)* |
| `spotbugs:check` passes | ❌ *(plugin missing)* |
| ≥ 80 % coverage on touched lines | ❌ *(no test jar)* |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ *(local)* |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why

Renamed the placeholder class `DummyClass` to `CachePlaceholder` for clarity. Updated references in `Game.java`.

## 🗂️ Detailed Changes
- `DummyClass.java` → `CachePlaceholder.java`
- Updated reference in `Game.java`

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| DummyClass | CachePlaceholder |

- **Batch**: single
- **Revert command**: `git revert -m 1 33cc66704cc1730282da70ac32e2b74eeadc2806`

## 📊 Diff Stat
```text
 .../src/main/java/{DummyClass.java => CachePlaceholder.java} | 6 +++---
 2006Scape Client/src/main/java/Game.java                    | 2 +-
 2 files changed, 4 insertions(+), 4 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded with warnings:
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
...
3 warnings
```
Test execution failed due to missing `tests-all.jar`:
```
Error: Unable to access jarfile tests-all.jar
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of **AGENTS.md** applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_68625fe97fd8832b9c6f30f9bd318ca4