### PR TITLE
[BOT] fix(shop): value fallback for Lime Whip

### DIFF
--- a/2006Scape Server/src/main/java/com/rs2/game/shops/ShopAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/shops/ShopAssistant.java
@@ -97,15 +97,23 @@ public class ShopAssistant {
 		}
 	}
 
-	public int getItemShopValue(int ItemID, int Type, boolean isSelling) {
-		double ShopValue = 1;
-		double TotPrice = 0;
-		double sellingRatio = isSelling ? 0.85 : 1;
-		if (ItemDefinition.lookup(ItemID) != null) {
-			ShopValue = ItemDefinition.lookup(ItemID).getValue() * sellingRatio;
-		}
+       public int getItemShopValue(int ItemID, int Type, boolean isSelling) {
+               double ShopValue = 1;
+               double TotPrice = 0;
+               double sellingRatio = isSelling ? 0.85 : 1;
 
-		TotPrice = ShopValue;
+               ItemDefinition def = ItemDefinition.lookup(ItemID);
+
+               if (def.getId() == -1 && ItemID == StaticItemList.LIME_WHIP) {
+                       // Fallback to abyssal whip value for custom lime whip
+                       def = ItemDefinition.lookup(StaticItemList.ABYSSAL_WHIP);
+               }
+
+               if (def.getId() != -1) {
+                       ShopValue = def.getValue() * sellingRatio;
+               }
+
+               TotPrice = ShopValue;
 
 		// General store pays less for items
 		if (isSelling && ShopHandler.shopBModifier[player.shopId] == 1) {


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Fixes selling price and shop handling for the custom Lime Whip. Previously the server treated the item as undefined causing a 1 gp value and null listing.

## 🗂️ Detailed Changes
- `ShopAssistant#getItemShopValue` now falls back to the Abyssal Whip value when the Lime Whip is encountered.

## 📊 Diff Stat
```text
.../java/com/rs2/game/shops/ShopAssistant.java | 24 ++++++++++++++--------
1 file changed, 16 insertions(+), 8 deletions(-)
```

## 🧪 Integration‑Test Log
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
...
3 warnings
```

## 📝 Rollback Plan
If this PR causes issues, revert with:
`git revert -m 1 f1c980e8`

------
https://chatgpt.com/codex/tasks/task_e_68627755d82c832b99d24e20f088dd58