### PR TITLE
[BOT] chore(cache): bump index count and revision

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -6901,53 +6901,53 @@ public class Game extends RSApplet {
 	
 	private void connectServer()
 	{
-	  int j = 5;
-		expectedCRCs[8] = 0;
-		int k = 0;
-		while(expectedCRCs[8] == 0)
-		{
+          int j = 5;
+               expectedCRCs[Signlink.INDEX_COUNT - 1] = 0;
+               int k = 0;
+               while(expectedCRCs[Signlink.INDEX_COUNT - 1] == 0)
+               {
 			String s = "Unknown problem";
 			drawLoadingText(20, "Connecting to web server");
 			try
 			{
-				DataInputStream datainputstream = openJagGrabInputStream("crc" + (int)(Math.random() * 99999999D) + "-" + 317);
+                               DataInputStream datainputstream = openJagGrabInputStream("crc" + (int)(Math.random() * 99999999D) + "-" + 470);
 				Stream class30_sub2_sub2 = new Stream(new byte[40]);
 				datainputstream.readFully(class30_sub2_sub2.buffer, 0, 40);
 				datainputstream.close();
-				for(int i1 = 0; i1 < 9; i1++)
-					expectedCRCs[i1] = class30_sub2_sub2.readDWord();
+                               for(int i1 = 0; i1 < Signlink.INDEX_COUNT; i1++)
+                                       expectedCRCs[i1] = class30_sub2_sub2.readDWord();
 
 				int j1 = class30_sub2_sub2.readDWord();
 				int k1 = 1234;
-				for(int l1 = 0; l1 < 9; l1++)
-					k1 = (k1 << 1) + expectedCRCs[l1];
+                               for(int l1 = 0; l1 < Signlink.INDEX_COUNT; l1++)
+                                       k1 = (k1 << 1) + expectedCRCs[l1];
 
 				if(j1 != k1)
 				{
 					s = "checksum problem";
-					expectedCRCs[8] = 0;
+                                       expectedCRCs[Signlink.INDEX_COUNT - 1] = 0;
 				}
 			}
 			catch(EOFException _ex)
 			{
-				s = "EOF problem";
-				expectedCRCs[8] = 0;
+                               s = "EOF problem";
+                               expectedCRCs[Signlink.INDEX_COUNT - 1] = 0;
 			}
 			catch(IOException _ex)
 			{
 				s = "FileServer Connection problem";
 				// Check if we already have cache files, if so then allow the client to load anyway
-				String cacheDir = Signlink.findcachedir();
-				expectedCRCs[8] = new File(cacheDir + "main_file_cache.dat").length() > 0 ? 1 : 0;
+                               String cacheDir = Signlink.findcachedir();
+                               expectedCRCs[Signlink.INDEX_COUNT - 1] = new File(cacheDir + "main_file_cache.dat").length() > 0 ? 1 : 0;
 			}
 			catch(Exception _ex)
 			{
-				s = "logic problem";
-				expectedCRCs[8] = 0;
+                               s = "logic problem";
+                               expectedCRCs[Signlink.INDEX_COUNT - 1] = 0;
 				if(!Signlink.reporterror)
 					return;
 			}
-			if(expectedCRCs[8] == 0)
+                       if(expectedCRCs[Signlink.INDEX_COUNT - 1] == 0)
 			{
 				k++;
 				for(int l = j; l > 0; l--)
@@ -6991,10 +6991,10 @@ public class Game extends RSApplet {
 			genericLoadingError = true;
 			return;
 		}
-		if (Signlink.cache_dat != null) {
-			for (int i = 0; i < 5; i++) {
-				decompressors[i] = new Decompressor(Signlink.cache_dat, Signlink.cache_idx[i], i + 1);
-			}
+               if (Signlink.cache_dat != null) {
+                       for (int i = 0; i < Signlink.INDEX_COUNT; i++) {
+                               decompressors[i] = new Decompressor(Signlink.cache_dat, Signlink.cache_idx[i], i + 1);
+                       }
 
 		}
 		try {
@@ -7013,7 +7013,7 @@ public class Game extends RSApplet {
 			StreamLoader streamLoader_2 = streamLoaderForName(4, "2d graphics", "media", expectedCRCs[4], 40);
 			StreamLoader streamLoader_3 = streamLoaderForName(6, "textures", "textures", expectedCRCs[6], 45);
 			StreamLoader streamLoader_4 = streamLoaderForName(7, "chat system", "wordenc", expectedCRCs[7], 50);
-			StreamLoader streamLoader_5 = streamLoaderForName(8, "sound effects", "sounds", expectedCRCs[8], 55);
+                       StreamLoader streamLoader_5 = streamLoaderForName(8, "sound effects", "sounds", expectedCRCs[Signlink.INDEX_COUNT - 1], 55);
 			byteGroundArray = new byte[4][104][104];
 			intGroundArray = new int[4][105][105];
 			worldController = new WorldController(intGroundArray);
@@ -12062,7 +12062,7 @@ public class Game extends RSApplet {
 		spriteDrawY = -1;
 		anIntArray968 = new int[33];
 		anIntArray969 = new int[256];
-		decompressors = new Decompressor[5];
+               decompressors = new Decompressor[Signlink.INDEX_COUNT];
 		variousSettings = new int[2000];
 		aBoolean972 = false;
 		anInt975 = 50;
@@ -12102,7 +12102,7 @@ public class Game extends RSApplet {
 		aBoolean1080 = false;
 		friendsList = new String[200];
 		inStream = Stream.create();
-		expectedCRCs = new int[9];
+               expectedCRCs = new int[Signlink.INDEX_COUNT];
 		menuActionCmd2 = new int[500];
 		menuActionCmd3 = new int[500];
 		menuActionID = new int[500];

--- a/2006Scape Client/src/main/java/Signlink.java
+++ b/2006Scape Client/src/main/java/Signlink.java
@@ -25,6 +25,9 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 
 public final class Signlink implements Runnable {
 
+       /** Number of cache indexes supported. */
+       public static final int INDEX_COUNT = 16;
+
 	public static final void startpriv(InetAddress inetaddress) {
 		threadliveid = (int) (Math.random() * 99999999D);
 		if (active) {
@@ -64,8 +67,8 @@ public final class Signlink implements Runnable {
 		String s = findcachedir();
 		try {
 			cache_dat = new RandomAccessFile(s + "main_file_cache.dat", "rw");
-			for (int j = 0; j < 5; j++)
-				cache_idx[j] = new RandomAccessFile(s + "main_file_cache.idx" + j, "rw");
+                       for (int j = 0; j < INDEX_COUNT; j++)
+                               cache_idx[j] = new RandomAccessFile(s + "main_file_cache.idx" + j, "rw");
 		} catch (Exception exception) {
 			exception.printStackTrace();
 		}
@@ -384,10 +387,10 @@ public final class Signlink implements Runnable {
 	private Signlink() {
 	}
 
-	public static final int clientversion = 317;
-	public static int storeid = 32;
-	public static RandomAccessFile cache_dat = null;
-	public static final RandomAccessFile[] cache_idx = new RandomAccessFile[5];
+       public static final int clientversion = 470;
+       public static int storeid = 32;
+       public static RandomAccessFile cache_dat = null;
+       public static final RandomAccessFile[] cache_idx = new RandomAccessFile[INDEX_COUNT];
 	public static boolean sunjava;
 	public static Applet mainapp = null;
 	private static boolean active;

--- a/2006Scape Server/src/main/java/org/apollo/cache/FileSystemConstants.java
+++ b/2006Scape Server/src/main/java/org/apollo/cache/FileSystemConstants.java
@@ -10,7 +10,7 @@ public final class FileSystemConstants {
 	/**
 	 * The number of archives in cache 0.
 	 */
-	public static final int ARCHIVE_COUNT = 9;
+       public static final int ARCHIVE_COUNT = 16;
 
 	/**
 	 * The size of a chunk.

--- a/2006Scape Server/src/main/java/org/apollo/cache/decoder/ItemDefinitionDecoder.java
+++ b/2006Scape Server/src/main/java/org/apollo/cache/decoder/ItemDefinitionDecoder.java
@@ -119,12 +119,24 @@ public final class ItemDefinitionDecoder implements Runnable {
 				buffer.getShort();
 			} else if (opcode >= 110 && opcode <= 112) {
 				buffer.getShort();
-			} else if (opcode == 113 || opcode == 114) {
-				buffer.get();
-			} else if (opcode == 115) {
-				definition.setTeam(buffer.get() & 0xFF);
-			}
-		}
-	}
+                       } else if (opcode == 113 || opcode == 114) {
+                               buffer.get();
+                       } else if (opcode == 115) {
+                               definition.setTeam(buffer.get() & 0xFF);
+                       } else if (opcode == 121) {
+                               buffer.getShort();
+                       } else if (opcode == 122) {
+                               buffer.getShort();
+                       } else if (opcode == 125) {
+                               buffer.get();
+                               buffer.get();
+                               buffer.get();
+                       } else if (opcode == 126) {
+                               buffer.getShort();
+                       } else {
+                               break;
+                       }
+               }
+       }
 
 }

--- a/2006Scape Server/src/main/java/org/apollo/cache/decoder/NpcDefinitionDecoder.java
+++ b/2006Scape Server/src/main/java/org/apollo/cache/decoder/NpcDefinitionDecoder.java
@@ -125,16 +125,18 @@ public final class NpcDefinitionDecoder implements Runnable {
 				buffer.get();
 			} else if (opcode == 102 || opcode == 103) {
 				buffer.getShort();
-			} else if (opcode == 106) {
-				wrap(buffer.getShort());
-				wrap(buffer.getShort());
+                       } else if (opcode == 106) {
+                               wrap(buffer.getShort());
+                               wrap(buffer.getShort());
 
 				int count = buffer.get() & 0xFF;
-				int[] morphisms = new int[count + 1];
-				Arrays.setAll(morphisms, index -> wrap(buffer.getShort()));
-			}
-		}
-	}
+                               int[] morphisms = new int[count + 1];
+                               Arrays.setAll(morphisms, index -> wrap(buffer.getShort()));
+                       } else {
+                               break;
+                       }
+               }
+       }
 
 	/**
 	 * Wraps a morphism value around, returning -1 if the specified value is 65,535.

--- a/2006Scape Server/src/main/java/org/apollo/cache/decoder/ObjectDefinitionDecoder.java
+++ b/2006Scape Server/src/main/java/org/apollo/cache/decoder/ObjectDefinitionDecoder.java
@@ -166,9 +166,9 @@ public final class ObjectDefinitionDecoder implements Runnable {
 				for (int i = 0; i <= count; i++) {
 					data.getShort();
 				}
-			} else {
-				continue;
-			}
+                       } else {
+                               break;
+                       }
 		}
 	}
 

--- a/2006Scape Server/src/main/java/org/apollo/net/codec/login/LoginDecoder.java
+++ b/2006Scape Server/src/main/java/org/apollo/net/codec/login/LoginDecoder.java
@@ -151,10 +151,10 @@ public final class LoginDecoder extends StatefulFrameDecoder<LoginDecoderState> 
 
 			boolean lowMemory = memoryStatus == 1;
 
-			int[] crcs = new int[FileSystemConstants.ARCHIVE_COUNT];
-			for (int index = 0; index < 9; index++) {
-				crcs[index] = payload.readInt();
-			}
+                       int[] crcs = new int[FileSystemConstants.ARCHIVE_COUNT];
+                       for (int index = 0; index < FileSystemConstants.ARCHIVE_COUNT; index++) {
+                               crcs[index] = payload.readInt();
+                       }
 
 			int length = payload.readUnsignedByte();
 			if (length != loginLength - 41) {


### PR DESCRIPTION
## Summary
- support more cache indexes in the client
- adjust revision constants and CRC handling
- stop infinite loops when decoding newer cache opcodes

## Testing
- `git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac`

------
https://chatgpt.com/codex/tasks/task_e_686298a23b3c832b8b84404e4be1f558