### PR TITLE
[BOT] refactor(rename): RasterProvider → RSImageProducer

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -2600,9 +2600,9 @@ public class Game extends RSApplet {
 		}
 		aClass30_Sub2_Sub1_Sub1_1201 = new Sprite(128, 265);
 		aClass30_Sub2_Sub1_Sub1_1202 = new Sprite(128, 265);
-		System.arraycopy(aRSImageProducer_1110.anIntArray315, 0, aClass30_Sub2_Sub1_Sub1_1201.pixels, 0, 33920);
+               System.arraycopy(aRSImageProducer_1110.pixels, 0, aClass30_Sub2_Sub1_Sub1_1201.pixels, 0, 33920);
 
-		System.arraycopy(aRSImageProducer_1111.anIntArray315, 0, aClass30_Sub2_Sub1_Sub1_1202.pixels, 0, 33920);
+               System.arraycopy(aRSImageProducer_1111.pixels, 0, aClass30_Sub2_Sub1_Sub1_1202.pixels, 0, 33920);
 
 		anIntArray851 = new int[256];
 		for (int k1 = 0; k1 < 64; k1++) {
@@ -9789,7 +9789,7 @@ public class Game extends RSApplet {
 			System.arraycopy(anIntArray851, 0, anIntArray850, 0, 256);
 
 		}
-		System.arraycopy(aClass30_Sub2_Sub1_Sub1_1201.pixels, 0, aRSImageProducer_1110.anIntArray315, 0, 33920);
+               System.arraycopy(aClass30_Sub2_Sub1_Sub1_1201.pixels, 0, aRSImageProducer_1110.pixels, 0, 33920);
 
 		int i1 = 0;
 		int j1 = 1152;
@@ -9806,8 +9806,8 @@ public class Game extends RSApplet {
 					int l3 = j3;
 					int j4 = 256 - j3;
 					j3 = anIntArray850[j3];
-					int l4 = aRSImageProducer_1110.anIntArray315[j1];
-					aRSImageProducer_1110.anIntArray315[j1++] = ((j3 & 0xff00ff) * l3 + (l4 & 0xff00ff) * j4 & 0xff00ff00) + ((j3 & 0xff00) * l3 + (l4 & 0xff00) * j4 & 0xff0000) >> 8;
+                                   int l4 = aRSImageProducer_1110.pixels[j1];
+                                   aRSImageProducer_1110.pixels[j1++] = ((j3 & 0xff00ff) * l3 + (l4 & 0xff00ff) * j4 & 0xff00ff00) + ((j3 & 0xff00) * l3 + (l4 & 0xff00) * j4 & 0xff0000) >> 8;
 				} else {
 					j1++;
 				}
@@ -9817,7 +9817,7 @@ public class Game extends RSApplet {
 		}
 
 		aRSImageProducer_1110.drawGraphics(0, super.graphics, 0);
-		System.arraycopy(aClass30_Sub2_Sub1_Sub1_1202.pixels, 0, aRSImageProducer_1111.anIntArray315, 0, 33920);
+               System.arraycopy(aClass30_Sub2_Sub1_Sub1_1202.pixels, 0, aRSImageProducer_1111.pixels, 0, 33920);
 
 		i1 = 0;
 		j1 = 1176;
@@ -9831,8 +9831,8 @@ public class Game extends RSApplet {
 					int i5 = k4;
 					int j5 = 256 - k4;
 					k4 = anIntArray850[k4];
-					int k5 = aRSImageProducer_1111.anIntArray315[j1];
-					aRSImageProducer_1111.anIntArray315[j1++] = ((k4 & 0xff00ff) * i5 + (k5 & 0xff00ff) * j5 & 0xff00ff00) + ((k4 & 0xff00) * i5 + (k5 & 0xff00) * j5 & 0xff0000) >> 8;
+                                   int k5 = aRSImageProducer_1111.pixels[j1];
+                                   aRSImageProducer_1111.pixels[j1++] = ((k4 & 0xff00ff) * i5 + (k5 & 0xff00ff) * j5 & 0xff00ff00) + ((k4 & 0xff00) * i5 + (k5 & 0xff00) * j5 & 0xff0000) >> 8;
 				} else {
 					j1++;
 				}

--- a/2006Scape Client/src/main/java/RSImageProducer.java
+++ b/2006Scape Client/src/main/java/RSImageProducer.java
@@ -13,77 +13,77 @@ import java.awt.image.ImageProducer;
 
 final class RSImageProducer implements ImageProducer, ImageObserver {
 
-	public RSImageProducer(int i, int j, Component component) {
-		anInt316 = i;
-		anInt317 = j;
-		anIntArray315 = new int[i * j];
-		aColorModel318 = new DirectColorModel(32, 0xff0000, 65280, 255);
-		anImage320 = component.createImage(this);
-		method239();
-		component.prepareImage(anImage320, this);
-		method239();
-		component.prepareImage(anImage320, this);
-		method239();
-		component.prepareImage(anImage320, this);
-		initDrawingArea();
-	}
+       public RSImageProducer(int width, int height, Component component) {
+               this.width = width;
+               this.height = height;
+               pixels = new int[width * height];
+               colorModel = new DirectColorModel(32, 0xff0000, 65280, 255);
+               image = component.createImage(this);
+               updateImage();
+               component.prepareImage(image, this);
+               updateImage();
+               component.prepareImage(image, this);
+               updateImage();
+               component.prepareImage(image, this);
+               initDrawingArea();
+       }
 
-	public void initDrawingArea() {
-		DrawingArea.initDrawingArea(anInt317, anInt316, anIntArray315);
-	}
+       public void initDrawingArea() {
+               DrawingArea.initDrawingArea(height, width, pixels);
+       }
 
-	public void drawGraphics(int i, Graphics g, int k) {
-		method239();
-		g.drawImage(anImage320, k, i, this);
-	}
-
-	@Override
-	public synchronized void addConsumer(ImageConsumer imageconsumer) {
-		anImageConsumer319 = imageconsumer;
-		imageconsumer.setDimensions(anInt316, anInt317);
-		imageconsumer.setProperties(null);
-		imageconsumer.setColorModel(aColorModel318);
-		imageconsumer.setHints(14);
-	}
+       public void drawGraphics(int i, Graphics g, int k) {
+               updateImage();
+               g.drawImage(image, k, i, this);
+       }
 
 	@Override
-	public synchronized boolean isConsumer(ImageConsumer imageconsumer) {
-		return anImageConsumer319 == imageconsumer;
-	}
+       public synchronized void addConsumer(ImageConsumer imageconsumer) {
+               this.imageConsumer = imageconsumer;
+               imageconsumer.setDimensions(width, height);
+               imageconsumer.setProperties(null);
+               imageconsumer.setColorModel(colorModel);
+               imageconsumer.setHints(14);
+       }
 
 	@Override
-	public synchronized void removeConsumer(ImageConsumer imageconsumer) {
-		if (anImageConsumer319 == imageconsumer) {
-			anImageConsumer319 = null;
-		}
-	}
+       public synchronized boolean isConsumer(ImageConsumer imageconsumer) {
+               return this.imageConsumer == imageconsumer;
+       }
 
 	@Override
-	public void startProduction(ImageConsumer imageconsumer) {
-		addConsumer(imageconsumer);
-	}
+       public synchronized void removeConsumer(ImageConsumer imageconsumer) {
+               if (this.imageConsumer == imageconsumer) {
+                       this.imageConsumer = null;
+               }
+       }
 
 	@Override
-	public void requestTopDownLeftRightResend(ImageConsumer imageconsumer) {
-		System.out.println("TDLR");
-	}
+       public void startProduction(ImageConsumer imageconsumer) {
+               addConsumer(imageconsumer);
+       }
 
-	private synchronized void method239() {
-		if (anImageConsumer319 != null) {
-			anImageConsumer319.setPixels(0, 0, anInt316, anInt317, aColorModel318, anIntArray315, 0, anInt316);
-			anImageConsumer319.imageComplete(2);
-		}
-	}
+	@Override
+       public void requestTopDownLeftRightResend(ImageConsumer imageconsumer) {
+               System.out.println("TDLR");
+       }
+
+       private synchronized void updateImage() {
+               if (imageConsumer != null) {
+                       imageConsumer.setPixels(0, 0, width, height, colorModel, pixels, 0, width);
+                       imageConsumer.imageComplete(2);
+               }
+       }
 
 	@Override
 	public boolean imageUpdate(Image image, int i, int j, int k, int l, int i1) {
 		return true;
 	}
 
-	public final int[] anIntArray315;
-	private final int anInt316;
-	private final int anInt317;
-	private final ColorModel aColorModel318;
-	private ImageConsumer anImageConsumer319;
-	private final Image anImage320;
+       public final int[] pixels;
+       private final int width;
+       private final int height;
+       private final ColorModel colorModel;
+       private ImageConsumer imageConsumer;
+       private final Image image;
 }


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Reverted the earlier class rename to `RasterProvider` while keeping the
improved field and method names. This preserves the original class
name `RSImageProducer` to better reflect the system's conventions.

## 🗂️ Detailed Changes
- Restored class name `RSImageProducer`
- Renamed its fields and the update method for clarity
- Updated `Game` references to use the new `pixels` field

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| `RasterProvider` | `RSImageProducer` |
| `method239` | `updateImage` |
| `anIntArray315` | `pixels` |
| `anInt316` | `width` |
| `anInt317` | `height` |
| `aColorModel318` | `colorModel` |
| `anImageConsumer319` | `imageConsumer` |
| `anImage320` | `image` |

- **Batch**: n/a
- **Revert command**: `git revert -m 1 9ada93b7`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java           |  16 +--
 .../src/main/java/RSImageProducer.java             | 108 ++++++++++-----------
 2 files changed, 62 insertions(+), 62 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeds with warnings:
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
2006Scape Client/src/main/java/Game.java:2767: warning: [removal] AppletContext in java.applet has been deprecated and marked for removal
        public AppletContext getAppletContext() {
               ^
2006Scape Client/src/main/java/Signlink.java:392: warning: [removal] Applet in java.applet has been deprecated and marked for removal
        public static Applet mainapp = null;
                      ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: 2006Scape Client/src/main/java/RSApplet.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
3 warnings
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, the agent will open an automatic
revert PR using the command above.


------
https://chatgpt.com/codex/tasks/task_e_6863bc60e8b8832b853252891e3a3a2d