### PR TITLE
[BOT] refactor(rename): forID → lookup

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -857,8 +857,8 @@ public class Game extends RSApplet {
 		ObjectDef.mruNodes1.unlinkAll();
 		ObjectDef.mruNodes2.unlinkAll();
 		EntityDef.mruNodes.unlinkAll();
-		ItemDef.mruNodes2.unlinkAll();
-		ItemDef.mruNodes1.unlinkAll();
+            ItemDef.modelCache.unlinkAll();
+            ItemDef.spriteCache.unlinkAll();
 		Player.mruNodes.unlinkAll();
 		SpotAnim.aMRUNodes_415.unlinkAll();
 	}
@@ -954,7 +954,7 @@ public class Game extends RSApplet {
 		long k = Long.MIN_VALUE;
 		Object obj = null;
 		for (Item item = (Item) class19.reverseGetFirst(); item != null; item = (Item) class19.reverseGetNext()) {
-			ItemDef itemDef = ItemDef.forID(item.ID);
+			ItemDef itemDef = ItemDef.lookup(item.ID);
 			long l = itemDef.value;
 			if (itemDef.stackable) {
 				l *= item.amount + 1;
@@ -1133,7 +1133,7 @@ public class Game extends RSApplet {
 								mouseInvInterfaceIndex = k2;
 								lastActiveInvInterface = class9_1.id;
 								if (class9_1.inv[k2] > 0) {
-									ItemDef itemDef = ItemDef.forID(class9_1.inv[k2] - 1);
+									ItemDef itemDef = ItemDef.lookup(class9_1.inv[k2] - 1);
 									if (itemSelected == 1 && class9_1.isInventoryInterface) {
 										if (class9_1.id != anInt1284 || k2 != anInt1283) {
 											menuActionName[menuActionRow] = "Use " + selectedItemName + " with @lre@" + itemDef.name;
@@ -1404,7 +1404,7 @@ public class Game extends RSApplet {
 			if (config == 4) {
 				Texture.method372(0.59999999999999998D);
 			}
-			ItemDef.mruNodes1.unlinkAll();
+            ItemDef.spriteCache.unlinkAll();
 			welcomeScreenRaised = true;
 		}
 		if (action == 3) {
@@ -1480,7 +1480,7 @@ public class Game extends RSApplet {
 					if (class19 != null) {
 						int offset = 5;
 						for (Item item = (Item) class19.reverseGetFirst(); item != null; item = (Item) class19.reverseGetNext()) {
-							ItemDef itemDef = ItemDef.forID(item.ID);
+							ItemDef itemDef = ItemDef.lookup(item.ID);
 							long totalValue = Math.max(1, item.amount) * Math.max(1, itemDef.value);
 							totalValue = totalValue > 0 ? totalValue : Integer.MAX_VALUE;
 							calcEntityScreenPos(k5 * 128 + 64, 20, l5 * 128 + 64);
@@ -4375,7 +4375,7 @@ public class Game extends RSApplet {
 			stream.writeShortA(k + baseY);
 		}
 		if (l == 1125) {
-			ItemDef itemDef = ItemDef.forID(i1);
+			ItemDef itemDef = ItemDef.lookup(i1);
 			RSInterface class9_4 = RSInterface.interfaceCache[k];
 			if (class9_4 != null && class9_4.invStackSizes[j] >= 1e5) {
 				DecimalFormatSymbols separator = new DecimalFormatSymbols();
@@ -4411,7 +4411,7 @@ public class Game extends RSApplet {
 			anInt1283 = j;
 			anInt1284 = k;
 			anInt1285 = i1;
-			selectedItemName = ItemDef.forID(i1).name;
+			selectedItemName = ItemDef.lookup(i1).name;
 			spellSelected = 0;
 			needDrawTabArea = true;
 			return;
@@ -4443,7 +4443,7 @@ public class Game extends RSApplet {
 			stream.writeShortA(i1);
 		}
 		if (l == 1448) {
-			ItemDef itemDef_1 = ItemDef.forID(i1);
+			ItemDef itemDef_1 = ItemDef.lookup(i1);
 			String s6;
 			if (itemDef_1.description != null) {
 				s6 = new String(itemDef_1.description) + " (" + intToKOrMil(itemDef_1.value) + "gp ea)";
@@ -4604,7 +4604,7 @@ public class Game extends RSApplet {
 				NodeList class19 = groundArray[plane][i1][j1];
 				if (class19 != null) {
 					for (Item item = (Item) class19.getFirst(); item != null; item = (Item) class19.getNext()) {
-						ItemDef itemDef = ItemDef.forID(item.ID);
+						ItemDef itemDef = ItemDef.lookup(item.ID);
 						if (itemSelected == 1) {
 							menuActionName[menuActionRow] = "Use " + selectedItemName + " with @lre@" + itemDef.name;
 							menuActionID[menuActionRow] = 511;
@@ -4789,7 +4789,7 @@ public class Game extends RSApplet {
 		nullLoader();
 		ObjectDef.nullLoader();
 		EntityDef.nullLoader();
-		ItemDef.nullLoader();
+        ItemDef.resetCache();
 		Flo.cache = null;
 		IDK.cache = null;
 		RSInterface.interfaceCache = null;
@@ -8464,7 +8464,7 @@ public class Game extends RSApplet {
 					for (int j5 = 0; j5 < component.height; j5++) {
 						for (int i6 = 0; i6 < component.width; i6++) {
 							if (component.inv[k4] > 0) {
-								ItemDef itemDef = ItemDef.forID(component.inv[k4] - 1);
+								ItemDef itemDef = ItemDef.lookup(component.inv[k4] - 1);
 								String s2 = itemDef.name;
 								if (itemDef.stackable || component.invStackSizes[k4] != 1) {
 									s2 = s2 + " x" + intToKOrMilLongName(component.invStackSizes[k4]);
@@ -9354,7 +9354,7 @@ public class Game extends RSApplet {
 				if (j1 == 4) {
 					RSInterface class9_1 = RSInterface.interfaceCache[ai[l++]];
 					int k2 = ai[l++];
-					if (k2 >= 0 && k2 < ItemDef.totalItems && (!ItemDef.forID(k2).membersObject || isMembers)) {
+					if (k2 >= 0 && k2 < ItemDef.totalItems && (!ItemDef.lookup(k2).membersObject || isMembers)) {
 						for (int j3 = 0; j3 < class9_1.inv.length; j3++) {
 							if (class9_1.inv[j3] == k2 + 1) {
 								k1 += class9_1.invStackSizes[j3];
@@ -9386,7 +9386,7 @@ public class Game extends RSApplet {
 				if (j1 == 10) {
 					RSInterface class9_2 = RSInterface.interfaceCache[ai[l++]];
 					int l2 = ai[l++] + 1;
-					if (l2 >= 0 && l2 < ItemDef.totalItems && (!ItemDef.forID(l2).membersObject || isMembers)) {
+					if (l2 >= 0 && l2 < ItemDef.totalItems && (!ItemDef.lookup(l2).membersObject || isMembers)) {
 						for (int element : class9_2.inv) {
 							if (element != l2) {
 								continue;
@@ -11431,7 +11431,7 @@ public class Game extends RSApplet {
 					pktType = -1;
 					return true;
 				} else {
-					ItemDef itemDef = ItemDef.forID(k18);
+					ItemDef itemDef = ItemDef.lookup(k18);
 					RSInterface.interfaceCache[i6].anInt233 = 4;
 					RSInterface.interfaceCache[i6].mediaID = k18;
 					RSInterface.interfaceCache[i6].anInt270 = itemDef.modelRotation1;
@@ -12814,7 +12814,7 @@ public class Game extends RSApplet {
         label0: for (int definition = 0; definition < amount; definition++) {
 			String result = "";
 			if (type == 1) {
-				ItemDef item = ItemDef.forID(definition);
+				ItemDef item = ItemDef.lookup(definition);
 				if (item.certTemplateID != -1 || item.name == null) {
 					continue;
 				}

--- a/2006Scape Client/src/main/java/Item.java
+++ b/2006Scape Client/src/main/java/Item.java
@@ -6,7 +6,7 @@ final class Item extends Animable {
 
 	@Override
 	public final Model getRotatedModel() {
-               ItemDef itemDef = ItemDef.forID(ID);
+               ItemDef itemDef = ItemDef.lookup(ID);
                return itemDef.getModel(amount);
 	}
 

--- a/2006Scape Client/src/main/java/ItemDef.java
+++ b/2006Scape Client/src/main/java/ItemDef.java
@@ -4,13 +4,13 @@
 
 public final class ItemDef {
 
-	public static void nullLoader() {
-		mruNodes2 = null;
-		mruNodes1 = null;
-		streamIndices = null;
-		cache = null;
-		stream = null;
-	}
+    public static void resetCache() {
+            modelCache = null;
+            spriteCache = null;
+            streamIndices = null;
+            cache = null;
+            stream = null;
+    }
 
        public boolean areDialogueModelsCached(int gender) {
                int head = maleHeadModel;
@@ -181,7 +181,7 @@ public final class ItemDef {
 		team = 0;
 	}
 
-	public static ItemDef forID(int i) {
+    public static ItemDef lookup(int i) {
 		for (int j = 0; j < 10; j++) {
 			if (cache[j].id == i) {
 				return cache[j];
@@ -200,9 +200,9 @@ public final class ItemDef {
                         itemDef.id = i;
                         itemDef.setDefaults();
                 }
-		if (itemDef.certTemplateID != -1) {
-			itemDef.toNote();
-		}
+                if (itemDef.certTemplateID != -1) {
+                        itemDef.convertToNote();
+                }
 		if (i == 6543) {
 			itemDef.name = "Magical Lamp";
 			itemDef.description = "I wonder what will happen when I rub this...".getBytes();
@@ -2050,8 +2050,8 @@ public final class ItemDef {
                 return itemDef;
         }
 
-	private void toNote() {
-		ItemDef itemDef = forID(certTemplateID);
+        private void convertToNote() {
+                ItemDef itemDef = lookup(certTemplateID);
 		modelID = itemDef.modelID;
 		modelZoom = itemDef.modelZoom;
 		modelRotation1 = itemDef.modelRotation1;
@@ -2062,7 +2062,7 @@ public final class ItemDef {
 		offsetY = itemDef.offsetY;
 		modifiedModelColors = itemDef.modifiedModelColors;
 		originalModelColors = itemDef.originalModelColors;
-		ItemDef itemDef_1 = forID(certID);
+                ItemDef itemDef_1 = lookup(certID);
 		name = itemDef_1.name;
 		membersObject = itemDef_1.membersObject;
 		value = itemDef_1.value;
@@ -2077,7 +2077,7 @@ public final class ItemDef {
 
 	public static Sprite getSprite(int i, int j, int k) {
 		if (k == 0) {
-			Sprite sprite = (Sprite) mruNodes1.insertFromCache(i);
+        Sprite sprite = (Sprite) spriteCache.insertFromCache(i);
 			if (sprite != null && sprite.trimHeight != j && sprite.trimHeight != -1) {
 				sprite.unlink();
 				sprite = null;
@@ -2086,7 +2086,7 @@ public final class ItemDef {
 				return sprite;
 			}
 		}
-		ItemDef itemDef = forID(i);
+                ItemDef itemDef = lookup(i);
 		if (itemDef.stackIDs == null) {
 			j = -1;
 		}
@@ -2099,7 +2099,7 @@ public final class ItemDef {
 			}
 
 			if (i1 != -1) {
-				itemDef = forID(i1);
+                                itemDef = lookup(i1);
 			}
 		}
                Model model = itemDef.getModel(1);
@@ -2194,7 +2194,7 @@ public final class ItemDef {
 			sprite.trimHeight = j6;
 		}
 		if (k == 0) {
-			mruNodes1.removeFromCache(sprite2, i);
+        spriteCache.removeFromCache(sprite2, i);
 		}
 		DrawingArea.initDrawingArea(j2, i2, ai1);
 		DrawingArea.setDrawingArea(j3, k2, l2, i3);
@@ -2221,10 +2221,10 @@ public final class ItemDef {
                        }
 
                        if (id != -1) {
-                               return forID(id).getModel(1);
+                               return lookup(id).getModel(1);
                        }
                }
-               Model model = (Model) mruNodes2.insertFromCache(id);
+        Model model = (Model) modelCache.insertFromCache(id);
 		if (model != null) {
 			return model;
 		}
@@ -2243,7 +2243,7 @@ public final class ItemDef {
 		}
 		model.method479(64 + ambient, 768 + contrast, -50, -10, -50, true);
 		model.aBoolean1659 = true;
-		mruNodes2.removeFromCache(model, id);
+        modelCache.removeFromCache(model, id);
 		return model;
 	}
 
@@ -2257,7 +2257,7 @@ public final class ItemDef {
                        }
 
                        if (id != -1) {
-                               return forID(id).getInterfaceModel(1);
+                               return lookup(id).getInterfaceModel(1);
                        }
                }
                Model model = Model.method462(modelID);
@@ -2390,8 +2390,8 @@ public final class ItemDef {
 	public int value;
 	private int[] modifiedModelColors;
 	public int id;
-	static MRUNodes mruNodes1 = new MRUNodes(100);
-	public static MRUNodes mruNodes2 = new MRUNodes(50);
+    static MRUNodes spriteCache = new MRUNodes(100);
+    public static MRUNodes modelCache = new MRUNodes(50);
 	private int[] originalModelColors;
 	public boolean membersObject;
 	private int femaleModel3;

--- a/2006Scape Client/src/main/java/Player.java
+++ b/2006Scape Client/src/main/java/Player.java
@@ -92,7 +92,7 @@ public final class Player extends Entity {
 				break;
 			}
 			if (equipment[j] >= 512 && equipment[j] - 512 < ItemDef.totalItems) {
-				int l1 = ItemDef.forID(equipment[j] - 512).team;
+				int l1 = ItemDef.lookup(equipment[j] - 512).team;
 				if (l1 != 0) {
 					team = l1;
 				}
@@ -209,7 +209,7 @@ public final class Player extends Entity {
 				if (k2 >= 256 && k2 < 512 && !IDK.cache[k2 - 256].method537()) {
 					flag = true;
 				}
-                               if (k2 >= 512 && !ItemDef.forID(k2 - 512).areWearModelsCached(anInt1702)) {
+                               if (k2 >= 512 && !ItemDef.lookup(k2 - 512).areWearModelsCached(anInt1702)) {
 					flag = true;
 				}
 			}
@@ -241,7 +241,7 @@ public final class Player extends Entity {
 					}
 				}
 				if (i3 >= 512) {
-                               Model model_4 = ItemDef.forID(i3 - 512).getWearModel(anInt1702);
+                               Model model_4 = ItemDef.lookup(i3 - 512).getWearModel(anInt1702);
 					if (model_4 != null) {
 						aclass30_sub2_sub4_sub6s[j2++] = model_4;
 					}
@@ -298,7 +298,7 @@ public final class Player extends Entity {
 			if (j >= 256 && j < 512 && !IDK.cache[j - 256].method539()) {
 				flag = true;
 			}
-                       if (j >= 512 && !ItemDef.forID(j - 512).areDialogueModelsCached(anInt1702)) {
+                       if (j >= 512 && !ItemDef.lookup(j - 512).areDialogueModelsCached(anInt1702)) {
 				flag = true;
 			}
 		}
@@ -317,7 +317,7 @@ public final class Player extends Entity {
 				}
 			}
 			if (i1 >= 512) {
-                               Model model_2 = ItemDef.forID(i1 - 512).getDialogueModel(anInt1702);
+                               Model model_2 = ItemDef.lookup(i1 - 512).getDialogueModel(anInt1702);
 				if (model_2 != null) {
 					aclass30_sub2_sub4_sub6s[k++] = model_2;
 				}

--- a/2006Scape Client/src/main/java/RSInterface.java
+++ b/2006Scape Client/src/main/java/RSInterface.java
@@ -234,7 +234,7 @@ public final class RSInterface {
 	private Model method206(int i, int j) {
 		ItemDef itemDefinition = null;
 		if (type == 4) {
-			itemDefinition = ItemDef.forID(id);
+			itemDefinition = ItemDef.lookup(id);
                        lightness += itemDefinition.ambient;
                        shading += itemDefinition.contrast;
 		}
@@ -248,7 +248,7 @@ public final class RSInterface {
 		if (i == 3)
 			model = Game.myPlayer.method453();
 		if (i == 4)
-                       model = ItemDef.forID(j).getInterfaceModel(50);
+                       model = ItemDef.lookup(j).getInterfaceModel(50);
 		if (i == 5)
 			model = null;
 		if (model != null)


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Renames several ItemDef identifiers to improve readability.

## 🗂️ Detailed Changes
- rename method `forID` → `lookup`
- rename method `nullLoader` → `resetCache`
- rename caches `mruNodes1` → `spriteCache` and `mruNodes2` → `modelCache`
- rename private helper `toNote` → `convertToNote`
- update all usages across Game, Player, Item, and RSInterface

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| `forID` | `lookup` |
| `nullLoader` | `resetCache` |
| `mruNodes1` | `spriteCache` |
| `mruNodes2` | `modelCache` |
| `toNote` | `convertToNote` |

- **Batch**: ItemDef
- **Revert command**: `git revert -m 1 2120fd60`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java        | 32 ++++++++---------
 2006Scape Client/src/main/java/Item.java        |  2 +-
 2006Scape Client/src/main/java/ItemDef.java     | 48 ++++++++++++-------------
 2006Scape Client/src/main/java/Player.java      | 10 +++---
 2006Scape Client/src/main/java/RSInterface.java |  4 +--
 5 files changed, 48 insertions(+), 48 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded with warnings:
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
...
3 warnings
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of AGENTS.md applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_6863fc6069d8832bb7e547a27b7bd05f