### PR TITLE
[BOT] refactor(rename): deobfuscate MidiFile members

### DIFF
--- a/2006Scape Client/src/main/java/MidiFile.java
+++ b/2006Scape Client/src/main/java/MidiFile.java
@@ -4,186 +4,186 @@
 
 final class MidiFile
 {
-    private static byte[] aByteArray210
+    private static byte[] opcodeSizeTable
 	= { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
 	    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
 	    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1,
 	    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	    1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
 	    2, 2, 0, 1, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    private Stream aClass3_Sub12_211 = new Stream(null);
-    private int[] anIntArray212;
-    int anInt213;
-    private int[] anIntArray214;
-    private long aLong215;
-    int[] anIntArray216;
-    private int[] anIntArray217;
-    private int anInt218;
+    private Stream stream = new Stream(null);
+    private int[] trackStatus;
+    int timeDivision;
+    private int[] trackPositions;
+    private long currentTime;
+    int[] trackTicks;
+    private int[] trackOffsets;
+    private int microsecondsPerQuarterNote;
     
-    final void method520(int i) {
-	int i_0_ = aClass3_Sub12_211.readUnsignedByteSub();
-	anIntArray216[i] += i_0_;
+    final void readDeltaTime(int i) {
+	int i_0_ = stream.readUnsignedByteSub();
+	trackTicks[i] += i_0_;
     }
     
-    final boolean method521() {
-	if (aClass3_Sub12_211.currentOffset >= 0)
+    final boolean isTrackFinished() {
+	if (stream.currentOffset >= 0)
 	    return false;
 	return true;
     }
     
-    final void method522(int i) {
-	anIntArray214[i] = aClass3_Sub12_211.currentOffset;
+    final void saveTrackPosition(int i) {
+	trackPositions[i] = stream.currentOffset;
     }
     
-    final void method523() {
-	aClass3_Sub12_211.buffer = null;
-	anIntArray217 = null;
-	anIntArray214 = null;
-	anIntArray216 = null;
-	anIntArray212 = null;
+    final void clear() {
+	stream.buffer = null;
+	trackOffsets = null;
+	trackPositions = null;
+	trackTicks = null;
+	trackStatus = null;
     }
     
-    private final int method524(int i) {
-	int i_1_ = (aClass3_Sub12_211.buffer
-		    [aClass3_Sub12_211.currentOffset]);
+    private final int readEvent(int i) {
+	int i_1_ = (stream.buffer
+		    [stream.currentOffset]);
 	if (i_1_ < 0) {
 	    i_1_ &= 0xff;
-	    anIntArray212[i] = i_1_;
-	    aClass3_Sub12_211.currentOffset++;
+	    trackStatus[i] = i_1_;
+	    stream.currentOffset++;
 	} else
-	    i_1_ = anIntArray212[i];
+	    i_1_ = trackStatus[i];
 	if (i_1_ == 240 || i_1_ == 247) {
-	    int i_2_ = aClass3_Sub12_211.readUnsignedByteSub();
+	    int i_2_ = stream.readUnsignedByteSub();
 	    if (i_1_ == 247 && i_2_ > 0) {
-		int i_3_ = ((aClass3_Sub12_211.buffer
-			     [aClass3_Sub12_211.currentOffset])
+		int i_3_ = ((stream.buffer
+			     [stream.currentOffset])
 			    & 0xff);
 		if (i_3_ >= 241 && i_3_ <= 243 || i_3_ == 246 || i_3_ == 248
 		    || i_3_ >= 250 && i_3_ <= 252 || i_3_ == 254) {
-		    aClass3_Sub12_211.currentOffset++;
-		    anIntArray212[i] = i_3_;
-		    return method535(i, i_3_);
+		    stream.currentOffset++;
+		    trackStatus[i] = i_3_;
+		    return parseEvent(i, i_3_);
 		}
 	    }
-	    aClass3_Sub12_211.currentOffset += i_2_;
+	    stream.currentOffset += i_2_;
 	    return 0;
 	}
-	return method535(i, i_1_);
+	return parseEvent(i, i_1_);
     }
     
-    final void method525(byte[] is) {
-	aClass3_Sub12_211.buffer = is;
-	aClass3_Sub12_211.currentOffset = 10;
-	int i = aClass3_Sub12_211.readUnsignedWord();
-	anInt213 = aClass3_Sub12_211.readUnsignedWord();
-	anInt218 = 500000;
-	anIntArray217 = new int[i];
+    final void load(byte[] is) {
+	stream.buffer = is;
+	stream.currentOffset = 10;
+	int i = stream.readUnsignedWord();
+	timeDivision = stream.readUnsignedWord();
+	microsecondsPerQuarterNote = 500000;
+	trackOffsets = new int[i];
 	int i_4_ = 0;
 	while (i_4_ < i) {
-	    int i_5_ = aClass3_Sub12_211.readDWord();
-	    int i_6_ = aClass3_Sub12_211.readDWord();
+	    int i_5_ = stream.readDWord();
+	    int i_6_ = stream.readDWord();
 	    if (i_5_ == 1297379947) {
-		anIntArray217[i_4_]
-		    = aClass3_Sub12_211.currentOffset;
+		trackOffsets[i_4_]
+		    = stream.currentOffset;
 		i_4_++;
 	    }
-	    aClass3_Sub12_211.currentOffset += i_6_;
+	    stream.currentOffset += i_6_;
 	}
-	anIntArray214 = anIntArray217.clone();
-	anIntArray216 = new int[i];
-	anIntArray212 = new int[i];
+	trackPositions = trackOffsets.clone();
+	trackTicks = new int[i];
+	trackStatus = new int[i];
     }
     
-    final void method526(int i) {
-	aClass3_Sub12_211.currentOffset = anIntArray214[i];
+    final void seekTrack(int i) {
+	stream.currentOffset = trackPositions[i];
     }
     
-    final boolean method527() {
-	if (aClass3_Sub12_211.buffer == null)
+    final boolean isLoaded() {
+	if (stream.buffer == null)
 	    return false;
 	return true;
     }
     
-    final void method528() {
-	aClass3_Sub12_211.currentOffset = -1;
+    final void markTrackEnd() {
+	stream.currentOffset = -1;
     }
     
-    final int method529(int i) {
-	int i_7_ = method524(i);
+    final int getNextEvent(int i) {
+	int i_7_ = readEvent(i);
 	return i_7_;
     }
     
     public static void reset() {
-	aByteArray210 = null;
+	opcodeSizeTable = null;
     }
     
-    final boolean method531() {
-	int i = anIntArray214.length;
+    final boolean allTracksFinished() {
+	int i = trackPositions.length;
 	for (int i_8_ = 0; i_8_ < i; i_8_++) {
-	    if (anIntArray214[i_8_] >= 0)
+	    if (trackPositions[i_8_] >= 0)
 		return false;
 	}
 	return true;
     }
     
-    final long method532(int i) {
-	return aLong215 + (long) i * (long) anInt218;
+    final long getTimeForTick(int i) {
+	return currentTime + (long) i * (long) microsecondsPerQuarterNote;
     }
     
-    final int method533() {
-	return anIntArray214.length;
+    final int getTrackCount() {
+	return trackPositions.length;
     }
     
-    final void method534(long l) {
-	aLong215 = l;
-	int i = anIntArray214.length;
+    final void resetTracks(long l) {
+	currentTime = l;
+	int i = trackPositions.length;
 	for (int i_9_ = 0; i_9_ < i; i_9_++) {
-	    anIntArray216[i_9_] = 0;
-	    anIntArray212[i_9_] = 0;
-	    aClass3_Sub12_211.currentOffset = anIntArray217[i_9_];
-	    method520(i_9_);
-	    anIntArray214[i_9_] = aClass3_Sub12_211.currentOffset;
+	    trackTicks[i_9_] = 0;
+	    trackStatus[i_9_] = 0;
+	    stream.currentOffset = trackOffsets[i_9_];
+	    readDeltaTime(i_9_);
+	    trackPositions[i_9_] = stream.currentOffset;
 	}
     }
     
-    private final int method535(int i, int i_10_) {
+    private final int parseEvent(int i, int i_10_) {
 	if (i_10_ == 255) {
-	    int i_11_ = aClass3_Sub12_211.readUnsignedByte();
-	    int i_12_ = aClass3_Sub12_211.readUnsignedByteSub();
+	    int i_11_ = stream.readUnsignedByte();
+	    int i_12_ = stream.readUnsignedByteSub();
 	    if (i_11_ == 47) {
-		aClass3_Sub12_211.currentOffset += i_12_;
+		stream.currentOffset += i_12_;
 		return 1;
 	    }
 	    if (i_11_ == 81) {
-		int i_13_ = aClass3_Sub12_211.read3Bytes();
+		int i_13_ = stream.read3Bytes();
 		i_12_ -= 3;
-		int i_14_ = anIntArray216[i];
-		aLong215 += (long) i_14_ * (long) (anInt218 - i_13_);
-		anInt218 = i_13_;
-		aClass3_Sub12_211.currentOffset += i_12_;
+		int i_14_ = trackTicks[i];
+		currentTime += (long) i_14_ * (long) (microsecondsPerQuarterNote - i_13_);
+		microsecondsPerQuarterNote = i_13_;
+		stream.currentOffset += i_12_;
 		return 2;
 	    }
-	    aClass3_Sub12_211.currentOffset += i_12_;
+	    stream.currentOffset += i_12_;
 	    return 3;
 	}
-	byte i_15_ = aByteArray210[i_10_ - 128];
+	byte i_15_ = opcodeSizeTable[i_10_ - 128];
 	int i_16_ = i_10_;
 	if (i_15_ >= 1)
-	    i_16_ |= aClass3_Sub12_211.readUnsignedByte() << 8;
+	    i_16_ |= stream.readUnsignedByte() << 8;
 	if (i_15_ >= 2)
-	    i_16_ |= aClass3_Sub12_211.readUnsignedByte() << 16;
+	    i_16_ |= stream.readUnsignedByte() << 16;
 	return i_16_;
     }
     
-    final int method536() {
-	int i = anIntArray214.length;
+    final int getNextTrack() {
+	int i = trackPositions.length;
 	int i_17_ = -1;
 	int i_18_ = 2147483647;
 	for (int i_19_ = 0; i_19_ < i; i_19_++) {
-	    if (anIntArray214[i_19_] >= 0
-		&& anIntArray216[i_19_] < i_18_) {
+	    if (trackPositions[i_19_] >= 0
+		&& trackTicks[i_19_] < i_18_) {
 		i_17_ = i_19_;
-		i_18_ = anIntArray216[i_19_];
+		i_18_ = trackTicks[i_19_];
 	    }
 	}
 	return i_17_;


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

> **PR Title format**: `[BOT] <type(scope)>: <summary>`\
> Example: `[BOT] refactor(rename): Class29 → SoundEnvelope`

---

## ✅ Pre‑flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

---

## 🔍 What & Why

Refactors the `MidiFile` class to replace obfuscated field and method names with more descriptive ones. `QueuedMidiPlayer` is updated to use the new API.

---

## 🗂️ Detailed Changes
- rename internal fields like `anIntArray216` → `trackTicks`
- rename methods such as `method520` → `readDeltaTime`
- adjust `QueuedMidiPlayer` to reference updated names

---

## ♻️ Rename‑Specific Fields

| Old Identifier | New Identifier |
| -------------- | -------------- |
| `method520` | `readDeltaTime` |
| `method521` | `isTrackFinished` |
| `method522` | `saveTrackPosition` |
| `method523` | `clear` |
| `method524` | `readEvent` |
| `method525` | `load` |
| `method526` | `seekTrack` |
| `method527` | `isLoaded` |
| `method528` | `markTrackEnd` |
| `method529` | `getNextEvent` |
| `method531` | `allTracksFinished` |
| `method532` | `getTimeForTick` |
| `method533` | `getTrackCount` |
| `method534` | `resetTracks` |
| `method535` | `parseEvent` |
| `method536` | `getNextTrack` |
| `anIntArray216` | `trackTicks` |
| `anInt213` | `timeDivision` |
| ... | ... |

- **Batch**: 
- **Revert command**: `git revert -m 1 62e11467`

---

## 📊 Diff Stat

```text
 2006Scape Client/src/main/java/MidiFile.java       | 192 ++++++++++-----------
 .../src/main/java/QueuedMidiPlayer.java            |  54 +++---
 2 files changed, 123 insertions(+), 123 deletions(-)
```

---

## 🧪 Integration‑Test Log

[Successful CI run](<!-- URL -->)

---

## 📝 Rollback Plan

If this PR causes a failure on `main`, Section 9 of **AGENTS.md** applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_6864051cdc64832bb51095a3eb03093c