### PR TITLE
[BOT] refactor(rename): deobfuscate ObjectDef

### DIFF
--- a/2006Scape Client/src/main/java/DynamicObject.java
+++ b/2006Scape Client/src/main/java/DynamicObject.java
@@ -39,7 +39,7 @@ final class DynamicObject extends Animable {
 		if (class46 == null) {
 			return null;
 		} else {
-			return class46.method578(type, orientation, tileHeight, tileHeight1, tileHeight2, tileHeight3, j);
+			return class46.getModel(type, orientation, tileHeight, tileHeight1, tileHeight2, tileHeight3, j);
 		}
 	}
 

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -2465,9 +2465,9 @@ public class Game extends RSApplet {
 			if (class46_2.anInt758 != -1) {
 				Background background_2 = mapScenes[class46_2.anInt758];
 				if (background_2 != null) {
-					int i6 = (class46_2.anInt744 * 4 - background_2.anInt1452) / 2;
-					int j6 = (class46_2.anInt761 * 4 - background_2.anInt1453) / 2;
-					background_2.method361(48 + l * 4 + i6, 48 + (104 - i - class46_2.anInt761) * 4 + j6);
+					int i6 = (class46_2.sizeX * 4 - background_2.anInt1452) / 2;
+					int j6 = (class46_2.sizeY * 4 - background_2.anInt1453) / 2;
+					background_2.method361(48 + l * 4 + i6, 48 + (104 - i - class46_2.sizeY) * 4 + j6);
 				}
 			} else {
 				if (i3 == 0 || i3 == 2) {
@@ -2539,9 +2539,9 @@ public class Game extends RSApplet {
 			if (class46_1.anInt758 != -1) {
 				Background background_1 = mapScenes[class46_1.anInt758];
 				if (background_1 != null) {
-					int j5 = (class46_1.anInt744 * 4 - background_1.anInt1452) / 2;
-					int k5 = (class46_1.anInt761 * 4 - background_1.anInt1453) / 2;
-					background_1.method361(48 + l * 4 + j5, 48 + (104 - i - class46_1.anInt761) * 4 + k5);
+					int j5 = (class46_1.sizeX * 4 - background_1.anInt1452) / 2;
+					int k5 = (class46_1.sizeY * 4 - background_1.anInt1453) / 2;
+					background_1.method361(48 + l * 4 + j5, 48 + (104 - i - class46_1.sizeY) * 4 + k5);
 				}
 			} else if (j3 == 9) {
 				int l4 = 0xeeeeee;
@@ -2570,9 +2570,9 @@ public class Game extends RSApplet {
 			if (class46.anInt758 != -1) {
 				Background background = mapScenes[class46.anInt758];
 				if (background != null) {
-					int i4 = (class46.anInt744 * 4 - background.anInt1452) / 2;
-					int j4 = (class46.anInt761 * 4 - background.anInt1453) / 2;
-					background.method361(48 + l * 4 + i4, 48 + (104 - i - class46.anInt761) * 4 + j4);
+					int i4 = (class46.sizeX * 4 - background.anInt1452) / 2;
+					int j4 = (class46.sizeY * 4 - background.anInt1453) / 2;
+					background.method361(48 + l * 4 + i4, 48 + (104 - i - class46.sizeY) * 4 + j4);
 				}
 			}
 		}
@@ -3410,11 +3410,11 @@ public class Game extends RSApplet {
 			int i2;
 			int j2;
 			if (l1 == 0 || l1 == 2) {
-				i2 = class46.anInt744;
-				j2 = class46.anInt761;
+				i2 = class46.sizeX;
+				j2 = class46.sizeY;
 			} else {
-				i2 = class46.anInt761;
-				j2 = class46.anInt744;
+				i2 = class46.sizeY;
+				j2 = class46.sizeX;
 			}
 			int k2 = class46.anInt768;
 			if (l1 != 0) {
@@ -4503,7 +4503,7 @@ public class Game extends RSApplet {
 			if (k1 == 2 && worldController.method304(plane, i1, j1, l) >= 0) {
 				ObjectDef class46 = ObjectDef.forID(l1);
 				if (class46.childrenIDs != null) {
-					class46 = class46.method580();
+					class46 = class46.getChildDefinition();
 				}
 				if (class46 == null) {
 					continue;
@@ -10165,17 +10165,17 @@ public class Game extends RSApplet {
 				int j22 = intGroundArray[plane][k4 + 1][j7];
 				int k22 = intGroundArray[plane][k4 + 1][j7 + 1];
 				int l22 = intGroundArray[plane][k4][j7 + 1];
-				Model model = class46.method578(j19, i20, i22, j22, k22, l22, -1);
+				Model model = class46.getModel(j19, i20, i22, j22, k22, l22, -1);
 				if (model != null) {
 					method130(k17 + 1, -1, 0, l20, j7, 0, plane, k4, l14 + 1);
 					player.anInt1707 = l14 + loopCycle;
 					player.anInt1708 = k17 + loopCycle;
 					player.aModel_1714 = model;
-					int i23 = class46.anInt744;
-					int j23 = class46.anInt761;
+					int i23 = class46.sizeX;
+					int j23 = class46.sizeY;
 					if (i20 == 1 || i20 == 3) {
-						i23 = class46.anInt761;
-						j23 = class46.anInt744;
+						i23 = class46.sizeY;
+						j23 = class46.sizeX;
 					}
 					player.anInt1711 = k4 * 128 + i23 * 64;
 					player.anInt1713 = j7 * 128 + j23 * 64;
@@ -10494,8 +10494,8 @@ public class Game extends RSApplet {
 				if (j1 == 0) {
 					worldController.method291(i1, j, i, (byte) -119);
 					ObjectDef class46 = ObjectDef.forID(j2);
-					if (class46.aBoolean767) {
-						aClass11Array1230[j].method215(l2, k2, class46.aBoolean757, i1, i);
+					if (class46.isSolid) {
+						aClass11Array1230[j].method215(l2, k2, class46.impenetrable, i1, i);
 					}
 				}
 				if (j1 == 1) {
@@ -10504,17 +10504,17 @@ public class Game extends RSApplet {
 				if (j1 == 2) {
 					worldController.method293(j, i1, i);
 					ObjectDef class46_1 = ObjectDef.forID(j2);
-					if (i1 + class46_1.anInt744 > 103 || i + class46_1.anInt744 > 103 || i1 + class46_1.anInt761 > 103 || i + class46_1.anInt761 > 103) {
+					if (i1 + class46_1.sizeX > 103 || i + class46_1.sizeX > 103 || i1 + class46_1.sizeY > 103 || i + class46_1.sizeY > 103) {
 						return;
 					}
-					if (class46_1.aBoolean767) {
-						aClass11Array1230[j].method216(l2, class46_1.anInt744, i1, i, class46_1.anInt761, class46_1.aBoolean757);
+					if (class46_1.isSolid) {
+						aClass11Array1230[j].method216(l2, class46_1.sizeX, i1, i, class46_1.sizeY, class46_1.impenetrable);
 					}
 				}
 				if (j1 == 3) {
 					worldController.method294(j, i, i1);
 					ObjectDef class46_2 = ObjectDef.forID(j2);
-					if (class46_2.aBoolean767 && class46_2.hasActions) {
+					if (class46_2.isSolid && class46_2.interactive) {
 						aClass11Array1230[j].method218(i, i1);
 					}
 				}

--- a/2006Scape Client/src/main/java/ObjectDef.java
+++ b/2006Scape Client/src/main/java/ObjectDef.java
@@ -16,7 +16,7 @@ public final class ObjectDef {
 		stream.currentOffset = streamIndices[i];
 		class46.type = i;
 		class46.setDefaults();
-		class46.readValues(stream);
+		class46.decode(stream);
 		if (i == 6) {
 			class46.actions[1] = "Load";
 			class46.actions[2] = "Pick-up";
@@ -28,21 +28,21 @@ public final class ObjectDef {
 	}
 
 	private void setDefaults() {
-		anIntArray773 = null;
-		anIntArray776 = null;
+		modelIds = null;
+		modelTypes = null;
 		name = null;
 		description = null;
 		modifiedModelColors = null;
 		originalModelColors = null;
-		anInt744 = 1;
-		anInt761 = 1;
-		aBoolean767 = true;
-		aBoolean757 = true;
-		hasActions = false;
+		sizeX = 1;
+		sizeY = 1;
+		isSolid = true;
+		impenetrable = true;
+		interactive = false;
 		aBoolean762 = false;
 		aBoolean769 = false;
 		aBoolean764 = false;
-		anInt781 = -1;
+		animationId = -1;
 		anInt775 = 16;
 		aByte737 = 0;
 		aByte742 = 0;
@@ -51,9 +51,9 @@ public final class ObjectDef {
 		anInt758 = -1;
 		aBoolean751 = false;
 		aBoolean779 = true;
-		anInt748 = 128;
-		anInt772 = 128;
-		anInt740 = 128;
+		scaleX = 128;
+		scaleY = 128;
+		scaleZ = 128;
 		anInt768 = 0;
 		anInt738 = 0;
 		anInt745 = 0;
@@ -66,11 +66,11 @@ public final class ObjectDef {
 		childrenIDs = null;
 	}
 
-	public void method574(OnDemandFetcher class42_sub1) {
-		if (anIntArray773 == null) {
+	public void requestModels(OnDemandFetcher class42_sub1) {
+		if (modelIds == null) {
 			return;
 		}
-		for (int element : anIntArray773) {
+		for (int element : modelIds) {
 			class42_sub1.method560(element & 0xffff, 0);
 		}
 	}
@@ -103,32 +103,32 @@ public final class ObjectDef {
 
 	}
 
-	public boolean method577(int i) {
-		if (anIntArray776 == null) {
-			if (anIntArray773 == null) {
+	public boolean isModelReady(int i) {
+		if (modelTypes == null) {
+			if (modelIds == null) {
 				return true;
 			}
 			if (i != 10) {
 				return true;
 			}
 			boolean flag1 = true;
-			for (int element : anIntArray773) {
+			for (int element : modelIds) {
 				flag1 &= Model.method463(element & 0xffff);
 			}
 
 			return flag1;
 		}
-		for (int j = 0; j < anIntArray776.length; j++) {
-			if (anIntArray776[j] == i) {
-				return Model.method463(anIntArray773[j] & 0xffff);
+		for (int j = 0; j < modelTypes.length; j++) {
+			if (modelTypes[j] == i) {
+				return Model.method463(modelIds[j] & 0xffff);
 			}
 		}
 
 		return true;
 	}
 
-	public Model method578(int i, int j, int k, int l, int i1, int j1, int k1) {
-		Model model = method581(i, k1, j);
+	public Model getModel(int i, int j, int k, int l, int i1, int j1, int k1) {
+		Model model = buildModel(i, k1, j);
 		if (model == null) {
 			return null;
 		}
@@ -151,18 +151,18 @@ public final class ObjectDef {
 		return model;
 	}
 
-	public boolean method579() {
-		if (anIntArray773 == null) {
+	public boolean areModelsReady() {
+		if (modelIds == null) {
 			return true;
 		}
 		boolean flag1 = true;
-		for (int element : anIntArray773) {
+		for (int element : modelIds) {
 			flag1 &= Model.method463(element & 0xffff);
 		}
 		return flag1;
 	}
 
-	public ObjectDef method580() {
+	public ObjectDef getChildDefinition() {
 		int i = -1;
 		if (anInt774 != -1) {
 			VarBit varBit = VarBit.cache[anInt774];
@@ -181,10 +181,10 @@ public final class ObjectDef {
 		}
 	}
 
-	private Model method581(int j, int k, int l) {
+	private Model buildModel(int j, int k, int l) {
 		Model model = null;
 		long l1;
-		if (anIntArray776 == null) {
+		if (modelTypes == null) {
 			if (j != 10) {
 				return null;
 			}
@@ -193,13 +193,13 @@ public final class ObjectDef {
 			if (model_1 != null) {
 				return model_1;
 			}
-			if (anIntArray773 == null) {
+			if (modelIds == null) {
 				return null;
 			}
 			boolean flag1 = aBoolean751 ^ l > 3;
-			int k1 = anIntArray773.length;
+			int k1 = modelIds.length;
 			for (int i2 = 0; i2 < k1; i2++) {
-				int l2 = anIntArray773[i2];
+				int l2 = modelIds[i2];
 				if (flag1) {
 					l2 += 0x10000;
 				}
@@ -224,8 +224,8 @@ public final class ObjectDef {
 			}
 		} else {
 			int i1 = -1;
-			for (int j1 = 0; j1 < anIntArray776.length; j1++) {
-				if (anIntArray776[j1] != j) {
+			for (int j1 = 0; j1 < modelTypes.length; j1++) {
+				if (modelTypes[j1] != j) {
 					continue;
 				}
 				i1 = j1;
@@ -240,7 +240,7 @@ public final class ObjectDef {
 			if (model_2 != null) {
 				return model_2;
 			}
-			int j2 = anIntArray773[i1];
+			int j2 = modelIds[i1];
 			boolean flag3 = aBoolean751 ^ l > 3;
 			if (flag3) {
 				j2 += 0x10000;
@@ -258,7 +258,7 @@ public final class ObjectDef {
 			}
 		}
 		boolean flag;
-		flag = anInt748 != 128 || anInt772 != 128 || anInt740 != 128;
+		flag = scaleX != 128 || scaleY != 128 || scaleZ != 128;
 		boolean flag2;
 		flag2 = anInt738 != 0 || anInt745 != 0 || anInt783 != 0;
                 Model model_3 = new Model(modifiedModelColors == null, AnimFrame.isNullFrame(k), l == 0 && k == -1 && !flag && !flag2, model);
@@ -278,7 +278,7 @@ public final class ObjectDef {
 
 		}
 		if (flag) {
-			model_3.method478(anInt748, anInt740, anInt772);
+			model_3.method478(scaleX, scaleZ, scaleY);
 		}
 		if (flag2) {
 			model_3.method475(anInt738, anInt745, anInt783);
@@ -291,7 +291,7 @@ public final class ObjectDef {
 		return model_3;
 	}
 
-	private void readValues(Stream stream) {
+	private void decode(Stream stream) {
 		int i = -1;
 		label0 : do {
 			int j;
@@ -303,12 +303,12 @@ public final class ObjectDef {
 				if (j == 1) {
 					int k = stream.readUnsignedByte();
 					if (k > 0) {
-						if (anIntArray773 == null || lowMem) {
-							anIntArray776 = new int[k];
-							anIntArray773 = new int[k];
+						if (modelIds == null || lowMem) {
+							modelTypes = new int[k];
+							modelIds = new int[k];
 							for (int k1 = 0; k1 < k; k1++) {
-								anIntArray773[k1] = stream.readUnsignedWord();
-								anIntArray776[k1] = stream.readUnsignedByte();
+								modelIds[k1] = stream.readUnsignedWord();
+								modelTypes[k1] = stream.readUnsignedByte();
 							}
 
 						} else {
@@ -322,11 +322,11 @@ public final class ObjectDef {
 				} else if (j == 5) {
 					int l = stream.readUnsignedByte();
 					if (l > 0) {
-						if (anIntArray773 == null || lowMem) {
-							anIntArray776 = null;
-							anIntArray773 = new int[l];
+						if (modelIds == null || lowMem) {
+							modelTypes = null;
+							modelIds = new int[l];
 							for (int l1 = 0; l1 < l; l1++) {
-								anIntArray773[l1] = stream.readUnsignedWord();
+								modelIds[l1] = stream.readUnsignedWord();
 							}
 
 						} else {
@@ -334,17 +334,17 @@ public final class ObjectDef {
 						}
 					}
 				} else if (j == 14) {
-					anInt744 = stream.readUnsignedByte();
+					sizeX = stream.readUnsignedByte();
 				} else if (j == 15) {
-					anInt761 = stream.readUnsignedByte();
+					sizeY = stream.readUnsignedByte();
 				} else if (j == 17) {
-					aBoolean767 = false;
+					isSolid = false;
 				} else if (j == 18) {
-					aBoolean757 = false;
+					impenetrable = false;
 				} else if (j == 19) {
 					i = stream.readUnsignedByte();
 					if (i == 1) {
-						hasActions = true;
+						interactive = true;
 					}
 				} else if (j == 21) {
 					aBoolean762 = true;
@@ -353,9 +353,9 @@ public final class ObjectDef {
 				} else if (j == 23) {
 					aBoolean764 = true;
 				} else if (j == 24) {
-					anInt781 = stream.readUnsignedWord();
-					if (anInt781 == 65535) {
-						anInt781 = -1;
+					animationId = stream.readUnsignedWord();
+					if (animationId == 65535) {
+						animationId = -1;
 					}
 				} else if (j == 28) {
 					anInt775 = stream.readUnsignedByte();
@@ -387,11 +387,11 @@ public final class ObjectDef {
 				} else if (j == 64) {
 					aBoolean779 = false;
 				} else if (j == 65) {
-					anInt748 = stream.readUnsignedWord();
+					scaleX = stream.readUnsignedWord();
 				} else if (j == 66) {
-					anInt772 = stream.readUnsignedWord();
+					scaleY = stream.readUnsignedWord();
 				} else if (j == 67) {
-					anInt740 = stream.readUnsignedWord();
+					scaleZ = stream.readUnsignedWord();
 				} else if (j == 68) {
 					anInt758 = stream.readUnsignedWord();
 				} else if (j == 69) {
@@ -433,17 +433,17 @@ public final class ObjectDef {
 
 		} while (true);
 		if (i == -1) {
-			hasActions = anIntArray773 != null && (anIntArray776 == null || anIntArray776[0] == 10);
+			interactive = modelIds != null && (modelTypes == null || modelTypes[0] == 10);
 			if (actions != null) {
-				hasActions = true;
+				interactive = true;
 			}
 		}
 		if (aBoolean766) {
-			aBoolean767 = false;
-			aBoolean757 = false;
+			isSolid = false;
+			impenetrable = false;
 		}
 		if (anInt760 == -1) {
-			anInt760 = aBoolean767 ? 1 : 0;
+			anInt760 = isSolid ? 1 : 0;
 		}
 	}
 
@@ -455,43 +455,43 @@ public final class ObjectDef {
 	private byte aByte737;
 	private int anInt738;
 	public String name;
-	private int anInt740;
+	private int scaleZ;
 	private static final Model[] aModelArray741s = new Model[4];
 	private byte aByte742;
-	public int anInt744;
+	public int sizeX;
 	private int anInt745;
 	public int anInt746;
 	private int[] originalModelColors;
-	private int anInt748;
+	private int scaleX;
 	public int anInt749;
 	private boolean aBoolean751;
 	public static boolean lowMem;
 	private static Stream stream;
 	public int type;
 	private static int[] streamIndices;
-	public boolean aBoolean757;
+	public boolean impenetrable;
 	public int anInt758;
 	public int childrenIDs[];
 	private int anInt760;
-	public int anInt761;
+	public int sizeY;
 	public boolean aBoolean762;
 	public boolean aBoolean764;
 	public static Game clientInstance;
 	private boolean aBoolean766;
-	public boolean aBoolean767;
+	public boolean isSolid;
 	public int anInt768;
 	private boolean aBoolean769;
 	private static int cacheIndex;
-	private int anInt772;
-	private int[] anIntArray773;
+	private int scaleY;
+	private int[] modelIds;
 	public int anInt774;
 	public int anInt775;
-	private int[] anIntArray776;
+	private int[] modelTypes;
 	public byte description[];
-	public boolean hasActions;
+	public boolean interactive;
 	public boolean aBoolean779;
 	public static MRUNodes mruNodes2 = new MRUNodes(30);
-	public int anInt781;
+	public int animationId;
 	private static ObjectDef[] cache;
 	private int anInt783;
 	private int[] modifiedModelColors;

--- a/2006Scape Client/src/main/java/ObjectManager.java
+++ b/2006Scape Client/src/main/java/ObjectManager.java
@@ -420,7 +420,7 @@ final class ObjectManager {
 				}
 				i += j;
 				ObjectDef class46 = ObjectDef.forID(i);
-				class46.method574(class42_sub1);
+				class46.requestModels(class42_sub1);
 				do {
 					int k = stream.readUnsignedSmart();
 					if (k == 0) {
@@ -474,32 +474,32 @@ final class ObjectManager {
 		int k2 = k1 + l1 + i2 + j2 >> 2;
 		ObjectDef class46 = ObjectDef.forID(i1);
 		int l2 = l + (i << 7) + (i1 << 14) + 0x40000000;
-		if (!class46.hasActions) {
+		if (!class46.interactive) {
 			l2 += 0x80000000;
 		}
 		byte byte0 = (byte) ((j1 << 6) + j);
 		if (j == 22) {
-			if (lowMem && !class46.hasActions && !class46.aBoolean736) {
+			if (lowMem && !class46.interactive && !class46.aBoolean736) {
 				return;
 			}
 			Object obj;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj = class46.method578(22, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj = class46.getModel(22, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj = new DynamicObject(i1, j1, 22, l1, i2, k1, j2, class46.anInt781, true);
+				obj = new DynamicObject(i1, j1, 22, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method280(k, k2, i, ((Animable) obj), byte0, l2, l);
-			if (class46.aBoolean767 && class46.hasActions && class11 != null) {
+			if (class46.isSolid && class46.interactive && class11 != null) {
 				class11.method213(i, l);
 			}
 			return;
 		}
 		if (j == 10 || j == 11) {
 			Object obj1;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj1 = class46.method578(10, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj1 = class46.getModel(10, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj1 = new DynamicObject(i1, j1, 10, l1, i2, k1, j2, class46.anInt781, true);
+				obj1 = new DynamicObject(i1, j1, 10, l1, i2, k1, j2, class46.animationId, true);
 			}
 			if (obj1 != null) {
 				int i5 = 0;
@@ -509,18 +509,18 @@ final class ObjectManager {
 				int j4;
 				int l4;
 				if (j1 == 1 || j1 == 3) {
-					j4 = class46.anInt761;
-					l4 = class46.anInt744;
+					j4 = class46.sizeY;
+					l4 = class46.sizeX;
 				} else {
-					j4 = class46.anInt744;
-					l4 = class46.anInt761;
+					j4 = class46.sizeX;
+					l4 = class46.sizeY;
 				}
 				if (worldController.method284(l2, byte0, k2, l4, ((Animable) obj1), j4, k, i5, i, l) && class46.aBoolean779) {
 					Model model;
 					if (obj1 instanceof Model) {
 						model = (Model) obj1;
 					} else {
-						model = class46.method578(10, j1, k1, l1, i2, j2, -1);
+						model = class46.getModel(10, j1, k1, l1, i2, j2, -1);
 					}
 					if (model != null) {
 						for (int j5 = 0; j5 <= j4; j5++) {
@@ -539,33 +539,33 @@ final class ObjectManager {
 					}
 				}
 			}
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method212(class46.aBoolean757, class46.anInt744, class46.anInt761, l, i, j1);
+			if (class46.isSolid && class11 != null) {
+				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
 			}
 			return;
 		}
 		if (j >= 12) {
 			Object obj2;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj2 = class46.method578(j, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj2 = class46.getModel(j, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj2 = new DynamicObject(i1, j1, j, l1, i2, k1, j2, class46.anInt781, true);
+				obj2 = new DynamicObject(i1, j1, j, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method284(l2, byte0, k2, 1, ((Animable) obj2), 1, k, 0, i, l);
 			if (j >= 12 && j <= 17 && j != 13 && k > 0) {
 				anIntArrayArrayArray135[k][l][i] |= 0x924;
 			}
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method212(class46.aBoolean757, class46.anInt744, class46.anInt761, l, i, j1);
+			if (class46.isSolid && class11 != null) {
+				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
 			}
 			return;
 		}
 		if (j == 0) {
 			Object obj3;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj3 = class46.method578(0, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj3 = class46.getModel(0, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj3 = new DynamicObject(i1, j1, 0, l1, i2, k1, j2, class46.anInt781, true);
+				obj3 = new DynamicObject(i1, j1, 0, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray152[j1], ((Animable) obj3), l2, i, byte0, l, null, k2, 0, k);
 			if (j1 == 0) {
@@ -601,8 +601,8 @@ final class ObjectManager {
 					anIntArrayArrayArray135[k][l][i] |= 0x492;
 				}
 			}
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method211(i, j1, l, j, class46.aBoolean757);
+			if (class46.isSolid && class11 != null) {
+				class11.method211(i, j1, l, j, class46.impenetrable);
 			}
 			if (class46.anInt775 != 16) {
 				worldController.method290(i, class46.anInt775, l, k);
@@ -611,10 +611,10 @@ final class ObjectManager {
 		}
 		if (j == 1) {
 			Object obj4;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj4 = class46.method578(1, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj4 = class46.getModel(1, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj4 = new DynamicObject(i1, j1, 1, l1, i2, k1, j2, class46.anInt781, true);
+				obj4 = new DynamicObject(i1, j1, 1, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray140[j1], ((Animable) obj4), l2, i, byte0, l, null, k2, 0, k);
 			if (class46.aBoolean779) {
@@ -628,8 +628,8 @@ final class ObjectManager {
 					aByteArrayArrayArray134[k][l][i] = 50;
 				}
 			}
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method211(i, j1, l, j, class46.aBoolean757);
+			if (class46.isSolid && class11 != null) {
+				class11.method211(i, j1, l, j, class46.impenetrable);
 			}
 			return;
 		}
@@ -637,12 +637,12 @@ final class ObjectManager {
 			int i3 = j1 + 1 & 3;
 			Object obj11;
 			Object obj12;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj11 = class46.method578(2, 4 + j1, k1, l1, i2, j2, -1);
-				obj12 = class46.method578(2, i3, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj11 = class46.getModel(2, 4 + j1, k1, l1, i2, j2, -1);
+				obj12 = class46.getModel(2, i3, k1, l1, i2, j2, -1);
 			} else {
-				obj11 = new DynamicObject(i1, 4 + j1, 2, l1, i2, k1, j2, class46.anInt781, true);
-				obj12 = new DynamicObject(i1, i3, 2, l1, i2, k1, j2, class46.anInt781, true);
+				obj11 = new DynamicObject(i1, 4 + j1, 2, l1, i2, k1, j2, class46.animationId, true);
+				obj12 = new DynamicObject(i1, i3, 2, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray152[j1], ((Animable) obj11), l2, i, byte0, l, ((Animable) obj12), k2, anIntArray152[i3], k);
 			if (class46.aBoolean764) {
@@ -660,8 +660,8 @@ final class ObjectManager {
 					anIntArrayArrayArray135[k][l][i] |= 0x249;
 				}
 			}
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method211(i, j1, l, j, class46.aBoolean757);
+			if (class46.isSolid && class11 != null) {
+				class11.method211(i, j1, l, j, class46.impenetrable);
 			}
 			if (class46.anInt775 != 16) {
 				worldController.method290(i, class46.anInt775, l, k);
@@ -670,10 +670,10 @@ final class ObjectManager {
 		}
 		if (j == 3) {
 			Object obj5;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj5 = class46.method578(3, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj5 = class46.getModel(3, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj5 = new DynamicObject(i1, j1, 3, l1, i2, k1, j2, class46.anInt781, true);
+				obj5 = new DynamicObject(i1, j1, 3, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray140[j1], ((Animable) obj5), l2, i, byte0, l, null, k2, 0, k);
 			if (class46.aBoolean779) {
@@ -687,21 +687,21 @@ final class ObjectManager {
 					aByteArrayArrayArray134[k][l][i] = 50;
 				}
 			}
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method211(i, j1, l, j, class46.aBoolean757);
+			if (class46.isSolid && class11 != null) {
+				class11.method211(i, j1, l, j, class46.impenetrable);
 			}
 			return;
 		}
 		if (j == 9) {
 			Object obj6;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj6 = class46.method578(j, j1, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj6 = class46.getModel(j, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj6 = new DynamicObject(i1, j1, j, l1, i2, k1, j2, class46.anInt781, true);
+				obj6 = new DynamicObject(i1, j1, j, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method284(l2, byte0, k2, 1, ((Animable) obj6), 1, k, 0, i, l);
-			if (class46.aBoolean767 && class11 != null) {
-				class11.method212(class46.aBoolean757, class46.anInt744, class46.anInt761, l, i, j1);
+			if (class46.isSolid && class11 != null) {
+				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
 			}
 			return;
 		}
@@ -729,10 +729,10 @@ final class ObjectManager {
 		}
 		if (j == 4) {
 			Object obj7;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj7 = class46.method578(4, 0, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj7 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj7 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.anInt781, true);
+				obj7 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method283(l2, i, j1 * 512, k, 0, k2, ((Animable) obj7), l, byte0, 0, anIntArray152[j1]);
 			return;
@@ -744,40 +744,40 @@ final class ObjectManager {
 				i4 = ObjectDef.forID(k4 >> 14 & 0x7fff).anInt775;
 			}
 			Object obj13;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj13 = class46.method578(4, 0, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj13 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj13 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.anInt781, true);
+				obj13 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method283(l2, i, j1 * 512, k, anIntArray137[j1] * i4, k2, ((Animable) obj13), l, byte0, anIntArray144[j1] * i4, anIntArray152[j1]);
 			return;
 		}
 		if (j == 6) {
 			Object obj8;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj8 = class46.method578(4, 0, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj8 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj8 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.anInt781, true);
+				obj8 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method283(l2, i, j1, k, 0, k2, ((Animable) obj8), l, byte0, 0, 256);
 			return;
 		}
 		if (j == 7) {
 			Object obj9;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj9 = class46.method578(4, 0, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj9 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj9 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.anInt781, true);
+				obj9 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method283(l2, i, j1, k, 0, k2, ((Animable) obj9), l, byte0, 0, 512);
 			return;
 		}
 		if (j == 8) {
 			Object obj10;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj10 = class46.method578(4, 0, k1, l1, i2, j2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj10 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj10 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.anInt781, true);
+				obj10 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
 			}
 			worldController.method283(l2, i, j1, k, 0, k2, ((Animable) obj10), l, byte0, 0, 768);
 		}
@@ -821,7 +821,7 @@ final class ObjectManager {
 		if (j >= 5 && j <= 8) {
 			j = 4;
 		}
-		return class46.method577(j);
+		return class46.isModelReady(j);
 	}
 
 	public final void method179(int i, int j, CollisionMap aclass11[], int l, int i1, byte abyte0[], int j1, int k1, int l1) {
@@ -964,8 +964,8 @@ final class ObjectManager {
 					int i4 = k3 & 3;
 					if (j3 == i && i3 >= i1 && i3 < i1 + 8 && l2 >= k && l2 < k + 8) {
 						ObjectDef class46 = ObjectDef.forID(l1);
-						int j4 = j + TileRotation.rotateWidth(j1, class46.anInt761, i3 & 7, l2 & 7, class46.anInt744);
-						int k4 = k1 + TileRotation.rotateHeight(l2 & 7, class46.anInt761, j1, class46.anInt744, i3 & 7);
+						int j4 = j + TileRotation.rotateWidth(j1, class46.sizeY, i3 & 7, l2 & 7, class46.sizeX);
+						int k4 = k1 + TileRotation.rotateHeight(l2 & 7, class46.sizeY, j1, class46.sizeX, i3 & 7);
 						if (j4 > 0 && k4 > 0 && j4 < 103 && k4 < 103) {
 							int l4 = j3;
 							if ((aByteArrayArrayArray149[1][j4][k4] & 2) == 2) {
@@ -1038,29 +1038,29 @@ final class ObjectManager {
 		int l2 = l1 + i2 + j2 + k2 >> 2;
 		ObjectDef class46 = ObjectDef.forID(j1);
 		int i3 = i1 + (j << 7) + (j1 << 14) + 0x40000000;
-		if (!class46.hasActions) {
+		if (!class46.interactive) {
 			i3 += 0x80000000;
 		}
 		byte byte1 = (byte) ((i << 6) + k);
 		if (k == 22) {
 			Object obj;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj = class46.method578(22, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj = class46.getModel(22, i, l1, i2, j2, k2, -1);
 			} else {
-				obj = new DynamicObject(j1, i, 22, i2, j2, l1, k2, class46.anInt781, true);
+				obj = new DynamicObject(j1, i, 22, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method280(k1, l2, j, ((Animable) obj), byte1, i3, i1);
-			if (class46.aBoolean767 && class46.hasActions) {
+			if (class46.isSolid && class46.interactive) {
 				class11.method213(j, i1);
 			}
 			return;
 		}
 		if (k == 10 || k == 11) {
 			Object obj1;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj1 = class46.method578(10, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj1 = class46.getModel(10, i, l1, i2, j2, k2, -1);
 			} else {
-				obj1 = new DynamicObject(j1, i, 10, i2, j2, l1, k2, class46.anInt781, true);
+				obj1 = new DynamicObject(j1, i, 10, i2, j2, l1, k2, class46.animationId, true);
 			}
 			if (obj1 != null) {
 				int j5 = 0;
@@ -1070,55 +1070,55 @@ final class ObjectManager {
 				int k4;
 				int i5;
 				if (i == 1 || i == 3) {
-					k4 = class46.anInt761;
-					i5 = class46.anInt744;
+					k4 = class46.sizeY;
+					i5 = class46.sizeX;
 				} else {
-					k4 = class46.anInt744;
-					i5 = class46.anInt761;
+					k4 = class46.sizeX;
+					i5 = class46.sizeY;
 				}
 				worldController.method284(i3, byte1, l2, i5, ((Animable) obj1), k4, k1, j5, j, i1);
 			}
-			if (class46.aBoolean767) {
-				class11.method212(class46.aBoolean757, class46.anInt744, class46.anInt761, i1, j, i);
+			if (class46.isSolid) {
+				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
 			}
 			return;
 		}
 		if (k >= 12) {
 			Object obj2;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj2 = class46.method578(k, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj2 = class46.getModel(k, i, l1, i2, j2, k2, -1);
 			} else {
-				obj2 = new DynamicObject(j1, i, k, i2, j2, l1, k2, class46.anInt781, true);
+				obj2 = new DynamicObject(j1, i, k, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method284(i3, byte1, l2, 1, ((Animable) obj2), 1, k1, 0, j, i1);
-			if (class46.aBoolean767) {
-				class11.method212(class46.aBoolean757, class46.anInt744, class46.anInt761, i1, j, i);
+			if (class46.isSolid) {
+				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
 			}
 			return;
 		}
 		if (k == 0) {
 			Object obj3;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj3 = class46.method578(0, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj3 = class46.getModel(0, i, l1, i2, j2, k2, -1);
 			} else {
-				obj3 = new DynamicObject(j1, i, 0, i2, j2, l1, k2, class46.anInt781, true);
+				obj3 = new DynamicObject(j1, i, 0, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray152[i], ((Animable) obj3), i3, j, byte1, i1, null, l2, 0, k1);
-			if (class46.aBoolean767) {
-				class11.method211(j, i, i1, k, class46.aBoolean757);
+			if (class46.isSolid) {
+				class11.method211(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
 		if (k == 1) {
 			Object obj4;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj4 = class46.method578(1, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj4 = class46.getModel(1, i, l1, i2, j2, k2, -1);
 			} else {
-				obj4 = new DynamicObject(j1, i, 1, i2, j2, l1, k2, class46.anInt781, true);
+				obj4 = new DynamicObject(j1, i, 1, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray140[i], ((Animable) obj4), i3, j, byte1, i1, null, l2, 0, k1);
-			if (class46.aBoolean767) {
-				class11.method211(j, i, i1, k, class46.aBoolean757);
+			if (class46.isSolid) {
+				class11.method211(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
@@ -1126,42 +1126,42 @@ final class ObjectManager {
 			int j3 = i + 1 & 3;
 			Object obj11;
 			Object obj12;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj11 = class46.method578(2, 4 + i, l1, i2, j2, k2, -1);
-				obj12 = class46.method578(2, j3, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj11 = class46.getModel(2, 4 + i, l1, i2, j2, k2, -1);
+				obj12 = class46.getModel(2, j3, l1, i2, j2, k2, -1);
 			} else {
-				obj11 = new DynamicObject(j1, 4 + i, 2, i2, j2, l1, k2, class46.anInt781, true);
-				obj12 = new DynamicObject(j1, j3, 2, i2, j2, l1, k2, class46.anInt781, true);
+				obj11 = new DynamicObject(j1, 4 + i, 2, i2, j2, l1, k2, class46.animationId, true);
+				obj12 = new DynamicObject(j1, j3, 2, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray152[i], ((Animable) obj11), i3, j, byte1, i1, ((Animable) obj12), l2, anIntArray152[j3], k1);
-			if (class46.aBoolean767) {
-				class11.method211(j, i, i1, k, class46.aBoolean757);
+			if (class46.isSolid) {
+				class11.method211(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
 		if (k == 3) {
 			Object obj5;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj5 = class46.method578(3, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj5 = class46.getModel(3, i, l1, i2, j2, k2, -1);
 			} else {
-				obj5 = new DynamicObject(j1, i, 3, i2, j2, l1, k2, class46.anInt781, true);
+				obj5 = new DynamicObject(j1, i, 3, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method282(anIntArray140[i], ((Animable) obj5), i3, j, byte1, i1, null, l2, 0, k1);
-			if (class46.aBoolean767) {
-				class11.method211(j, i, i1, k, class46.aBoolean757);
+			if (class46.isSolid) {
+				class11.method211(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
 		if (k == 9) {
 			Object obj6;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj6 = class46.method578(k, i, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj6 = class46.getModel(k, i, l1, i2, j2, k2, -1);
 			} else {
-				obj6 = new DynamicObject(j1, i, k, i2, j2, l1, k2, class46.anInt781, true);
+				obj6 = new DynamicObject(j1, i, k, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method284(i3, byte1, l2, 1, ((Animable) obj6), 1, k1, 0, j, i1);
-			if (class46.aBoolean767) {
-				class11.method212(class46.aBoolean757, class46.anInt744, class46.anInt761, i1, j, i);
+			if (class46.isSolid) {
+				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
 			}
 			return;
 		}
@@ -1189,10 +1189,10 @@ final class ObjectManager {
 		}
 		if (k == 4) {
 			Object obj7;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj7 = class46.method578(4, 0, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj7 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj7 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.anInt781, true);
+				obj7 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method283(i3, j, i * 512, k1, 0, l2, ((Animable) obj7), i1, byte1, 0, anIntArray152[i]);
 			return;
@@ -1204,40 +1204,40 @@ final class ObjectManager {
 				j4 = ObjectDef.forID(l4 >> 14 & 0x7fff).anInt775;
 			}
 			Object obj13;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj13 = class46.method578(4, 0, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj13 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj13 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.anInt781, true);
+				obj13 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method283(i3, j, i * 512, k1, anIntArray137[i] * j4, l2, ((Animable) obj13), i1, byte1, anIntArray144[i] * j4, anIntArray152[i]);
 			return;
 		}
 		if (k == 6) {
 			Object obj8;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj8 = class46.method578(4, 0, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj8 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj8 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.anInt781, true);
+				obj8 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method283(i3, j, i, k1, 0, l2, ((Animable) obj8), i1, byte1, 0, 256);
 			return;
 		}
 		if (k == 7) {
 			Object obj9;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj9 = class46.method578(4, 0, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj9 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj9 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.anInt781, true);
+				obj9 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method283(i3, j, i, k1, 0, l2, ((Animable) obj9), i1, byte1, 0, 512);
 			return;
 		}
 		if (k == 8) {
 			Object obj10;
-			if (class46.anInt781 == -1 && class46.childrenIDs == null) {
-				obj10 = class46.method578(4, 0, l1, i2, j2, k2, -1);
+			if (class46.animationId == -1 && class46.childrenIDs == null) {
+				obj10 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj10 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.anInt781, true);
+				obj10 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
 			}
 			worldController.method283(i3, j, i, k1, 0, l2, ((Animable) obj10), i1, byte1, 0, 768);
 		}
@@ -1279,8 +1279,8 @@ final class ObjectManager {
 					int i_262_ = i_258_ + i_250_;
 					if (i_261_ > 0 && i_262_ > 0 && i_261_ < 103 && i_262_ < 103) {
 						ObjectDef class46 = ObjectDef.forID(i_252_);
-						if (i_260_ != 22 || !lowMem || class46.hasActions || class46.aBoolean736) {
-							bool &= class46.method579();
+						if (i_260_ != 22 || !lowMem || class46.interactive || class46.aBoolean736) {
+							bool &= class46.areModelsReady();
 							bool_255_ = true;
 						}
 					}


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item | Status |
| - | - |
| `mvn -B verify -o` passes (offline) | n/a |
| `spotbugs:check` passes | n/a |
| ≥ 80 % coverage on touched lines | n/a |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why
Renamed several obfuscated methods and fields in `ObjectDef` to improve readability while preserving behaviour.

## 🗂️ Detailed Changes
- updated method names and member fields in `ObjectDef`
- adjusted all calling code in `DynamicObject`, `ObjectManager`, and `Game`

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| method574 | requestModels |
| method577 | isModelReady |
| method578 | getModel |
| method579 | areModelsReady |
| method580 | getChildDefinition |
| method581 | buildModel |
| readValues | decode |
| anIntArray773 | modelIds |
| anIntArray776 | modelTypes |
| anInt744 | sizeX |
| anInt761 | sizeY |
| aBoolean767 | isSolid |
| aBoolean757 | impenetrable |
| anInt748 | scaleX |
| anInt772 | scaleY |
| anInt740 | scaleZ |
| anInt781 | animationId |
| hasActions | interactive |

- **Batch**: 
- **Revert command**: `git revert -m 1 f3fbf50c06814281e7dce08df03ce044b468cd95`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/DynamicObject.java |   2 +-
 2006Scape Client/src/main/java/Game.java          |  50 ++---
 2006Scape Client/src/main/java/ObjectDef.java     | 150 ++++++-------
 2006Scape Client/src/main/java/ObjectManager.java | 260 +++++++++++-----------
 4 files changed, 231 insertions(+), 231 deletions(-)
```

## 🧪 Integration-Test Log
Compilation via `javac` succeeded with warnings.

## 📝 Rollback Plan
If this PR causes issues, revert using the command above.


------
https://chatgpt.com/codex/tasks/task_e_68640b9455ec832b9f2a95a0667d47de