### PR TITLE
[BOT] refactor(rename): CollisionMap method cleanup

### DIFF
--- a/2006Scape Client/src/main/java/CollisionMap.java
+++ b/2006Scape Client/src/main/java/CollisionMap.java
@@ -5,21 +5,21 @@
 final class CollisionMap {
 
 	public CollisionMap() {
-		anInt290 = 0;
-		anInt291 = 0;
-		anInt292 = 104;
-		anInt293 = 104;
-		anIntArrayArray294 = new int[anInt292][anInt293];
-		method210();
+		xInset = 0;
+		yInset = 0;
+		width = 104;
+		height = 104;
+		clippingFlags = new int[width][height];
+		reset();
 	}
 
-	public void method210() {
-		for (int i = 0; i < anInt292; i++) {
-			for (int j = 0; j < anInt293; j++) {
-				if (i == 0 || j == 0 || i == anInt292 - 1 || j == anInt293 - 1) {
-					anIntArrayArray294[i][j] = 0xffffff;
+	public void reset() {
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < height; j++) {
+				if (i == 0 || j == 0 || i == width - 1 || j == height - 1) {
+					clippingFlags[i][j] = 0xffffff;
 				} else {
-					anIntArrayArray294[i][j] = 0x1000000;
+					clippingFlags[i][j] = 0x1000000;
 				}
 			}
 
@@ -27,146 +27,146 @@ final class CollisionMap {
 
 	}
 
-	public void method211(int i, int j, int k, int l, boolean flag) {
-		k -= anInt290;
-		i -= anInt291;
+	public void addWall(int i, int j, int k, int l, boolean flag) {
+		k -= xInset;
+		i -= yInset;
 		if (l == 0) {
 			if (j == 0) {
-				method214(k, i, 128);
-				method214(k - 1, i, 8);
+				addFlag(k, i, 128);
+				addFlag(k - 1, i, 8);
 			}
 			if (j == 1) {
-				method214(k, i, 2);
-				method214(k, i + 1, 32);
+				addFlag(k, i, 2);
+				addFlag(k, i + 1, 32);
 			}
 			if (j == 2) {
-				method214(k, i, 8);
-				method214(k + 1, i, 128);
+				addFlag(k, i, 8);
+				addFlag(k + 1, i, 128);
 			}
 			if (j == 3) {
-				method214(k, i, 32);
-				method214(k, i - 1, 2);
+				addFlag(k, i, 32);
+				addFlag(k, i - 1, 2);
 			}
 		}
 		if (l == 1 || l == 3) {
 			if (j == 0) {
-				method214(k, i, 1);
-				method214(k - 1, i + 1, 16);
+				addFlag(k, i, 1);
+				addFlag(k - 1, i + 1, 16);
 			}
 			if (j == 1) {
-				method214(k, i, 4);
-				method214(k + 1, i + 1, 64);
+				addFlag(k, i, 4);
+				addFlag(k + 1, i + 1, 64);
 			}
 			if (j == 2) {
-				method214(k, i, 16);
-				method214(k + 1, i - 1, 1);
+				addFlag(k, i, 16);
+				addFlag(k + 1, i - 1, 1);
 			}
 			if (j == 3) {
-				method214(k, i, 64);
-				method214(k - 1, i - 1, 4);
+				addFlag(k, i, 64);
+				addFlag(k - 1, i - 1, 4);
 			}
 		}
 		if (l == 2) {
 			if (j == 0) {
-				method214(k, i, 130);
-				method214(k - 1, i, 8);
-				method214(k, i + 1, 32);
+				addFlag(k, i, 130);
+				addFlag(k - 1, i, 8);
+				addFlag(k, i + 1, 32);
 			}
 			if (j == 1) {
-				method214(k, i, 10);
-				method214(k, i + 1, 32);
-				method214(k + 1, i, 128);
+				addFlag(k, i, 10);
+				addFlag(k, i + 1, 32);
+				addFlag(k + 1, i, 128);
 			}
 			if (j == 2) {
-				method214(k, i, 40);
-				method214(k + 1, i, 128);
-				method214(k, i - 1, 2);
+				addFlag(k, i, 40);
+				addFlag(k + 1, i, 128);
+				addFlag(k, i - 1, 2);
 			}
 			if (j == 3) {
-				method214(k, i, 160);
-				method214(k, i - 1, 2);
-				method214(k - 1, i, 8);
+				addFlag(k, i, 160);
+				addFlag(k, i - 1, 2);
+				addFlag(k - 1, i, 8);
 			}
 		}
 		if (flag) {
 			if (l == 0) {
 				if (j == 0) {
-					method214(k, i, 0x10000);
-					method214(k - 1, i, 4096);
+					addFlag(k, i, 0x10000);
+					addFlag(k - 1, i, 4096);
 				}
 				if (j == 1) {
-					method214(k, i, 1024);
-					method214(k, i + 1, 16384);
+					addFlag(k, i, 1024);
+					addFlag(k, i + 1, 16384);
 				}
 				if (j == 2) {
-					method214(k, i, 4096);
-					method214(k + 1, i, 0x10000);
+					addFlag(k, i, 4096);
+					addFlag(k + 1, i, 0x10000);
 				}
 				if (j == 3) {
-					method214(k, i, 16384);
-					method214(k, i - 1, 1024);
+					addFlag(k, i, 16384);
+					addFlag(k, i - 1, 1024);
 				}
 			}
 			if (l == 1 || l == 3) {
 				if (j == 0) {
-					method214(k, i, 512);
-					method214(k - 1, i + 1, 8192);
+					addFlag(k, i, 512);
+					addFlag(k - 1, i + 1, 8192);
 				}
 				if (j == 1) {
-					method214(k, i, 2048);
-					method214(k + 1, i + 1, 32768);
+					addFlag(k, i, 2048);
+					addFlag(k + 1, i + 1, 32768);
 				}
 				if (j == 2) {
-					method214(k, i, 8192);
-					method214(k + 1, i - 1, 512);
+					addFlag(k, i, 8192);
+					addFlag(k + 1, i - 1, 512);
 				}
 				if (j == 3) {
-					method214(k, i, 32768);
-					method214(k - 1, i - 1, 2048);
+					addFlag(k, i, 32768);
+					addFlag(k - 1, i - 1, 2048);
 				}
 			}
 			if (l == 2) {
 				if (j == 0) {
-					method214(k, i, 0x10400);
-					method214(k - 1, i, 4096);
-					method214(k, i + 1, 16384);
+					addFlag(k, i, 0x10400);
+					addFlag(k - 1, i, 4096);
+					addFlag(k, i + 1, 16384);
 				}
 				if (j == 1) {
-					method214(k, i, 5120);
-					method214(k, i + 1, 16384);
-					method214(k + 1, i, 0x10000);
+					addFlag(k, i, 5120);
+					addFlag(k, i + 1, 16384);
+					addFlag(k + 1, i, 0x10000);
 				}
 				if (j == 2) {
-					method214(k, i, 20480);
-					method214(k + 1, i, 0x10000);
-					method214(k, i - 1, 1024);
+					addFlag(k, i, 20480);
+					addFlag(k + 1, i, 0x10000);
+					addFlag(k, i - 1, 1024);
 				}
 				if (j == 3) {
-					method214(k, i, 0x14000);
-					method214(k, i - 1, 1024);
-					method214(k - 1, i, 4096);
+					addFlag(k, i, 0x14000);
+					addFlag(k, i - 1, 1024);
+					addFlag(k - 1, i, 4096);
 				}
 			}
 		}
 	}
 
-	public void method212(boolean flag, int j, int k, int l, int i1, int j1) {
+	public void addObject(boolean flag, int j, int k, int l, int i1, int j1) {
 		int k1 = 256;
 		if (flag) {
 			k1 += 0x20000;
 		}
-		l -= anInt290;
-		i1 -= anInt291;
+		l -= xInset;
+		i1 -= yInset;
 		if (j1 == 1 || j1 == 3) {
 			int l1 = j;
 			j = k;
 			k = l1;
 		}
 		for (int i2 = l; i2 < l + j; i2++) {
-			if (i2 >= 0 && i2 < anInt292) {
+			if (i2 >= 0 && i2 < width) {
 				for (int j2 = i1; j2 < i1 + k; j2++) {
-					if (j2 >= 0 && j2 < anInt293) {
-						method214(i2, j2, k1);
+					if (j2 >= 0 && j2 < height) {
+						addFlag(i2, j2, k1);
 					}
 				}
 
@@ -175,156 +175,156 @@ final class CollisionMap {
 
 	}
 
-	public void method213(int i, int k) {
-		k -= anInt290;
-		i -= anInt291;
-		anIntArrayArray294[k][i] |= 0x200000;
+	public void blockTile(int i, int k) {
+		k -= xInset;
+		i -= yInset;
+		clippingFlags[k][i] |= 0x200000;
 	}
 
-	private void method214(int i, int j, int k) {
-		anIntArrayArray294[i][j] |= k;
+	private void addFlag(int i, int j, int k) {
+		clippingFlags[i][j] |= k;
 	}
 
-	public void method215(int i, int j, boolean flag, int k, int l) {
-		k -= anInt290;
-		l -= anInt291;
+	public void removeWall(int i, int j, boolean flag, int k, int l) {
+		k -= xInset;
+		l -= yInset;
 		if (j == 0) {
 			if (i == 0) {
-				method217(128, k, l);
-				method217(8, k - 1, l);
+				removeFlag(128, k, l);
+				removeFlag(8, k - 1, l);
 			}
 			if (i == 1) {
-				method217(2, k, l);
-				method217(32, k, l + 1);
+				removeFlag(2, k, l);
+				removeFlag(32, k, l + 1);
 			}
 			if (i == 2) {
-				method217(8, k, l);
-				method217(128, k + 1, l);
+				removeFlag(8, k, l);
+				removeFlag(128, k + 1, l);
 			}
 			if (i == 3) {
-				method217(32, k, l);
-				method217(2, k, l - 1);
+				removeFlag(32, k, l);
+				removeFlag(2, k, l - 1);
 			}
 		}
 		if (j == 1 || j == 3) {
 			if (i == 0) {
-				method217(1, k, l);
-				method217(16, k - 1, l + 1);
+				removeFlag(1, k, l);
+				removeFlag(16, k - 1, l + 1);
 			}
 			if (i == 1) {
-				method217(4, k, l);
-				method217(64, k + 1, l + 1);
+				removeFlag(4, k, l);
+				removeFlag(64, k + 1, l + 1);
 			}
 			if (i == 2) {
-				method217(16, k, l);
-				method217(1, k + 1, l - 1);
+				removeFlag(16, k, l);
+				removeFlag(1, k + 1, l - 1);
 			}
 			if (i == 3) {
-				method217(64, k, l);
-				method217(4, k - 1, l - 1);
+				removeFlag(64, k, l);
+				removeFlag(4, k - 1, l - 1);
 			}
 		}
 		if (j == 2) {
 			if (i == 0) {
-				method217(130, k, l);
-				method217(8, k - 1, l);
-				method217(32, k, l + 1);
+				removeFlag(130, k, l);
+				removeFlag(8, k - 1, l);
+				removeFlag(32, k, l + 1);
 			}
 			if (i == 1) {
-				method217(10, k, l);
-				method217(32, k, l + 1);
-				method217(128, k + 1, l);
+				removeFlag(10, k, l);
+				removeFlag(32, k, l + 1);
+				removeFlag(128, k + 1, l);
 			}
 			if (i == 2) {
-				method217(40, k, l);
-				method217(128, k + 1, l);
-				method217(2, k, l - 1);
+				removeFlag(40, k, l);
+				removeFlag(128, k + 1, l);
+				removeFlag(2, k, l - 1);
 			}
 			if (i == 3) {
-				method217(160, k, l);
-				method217(2, k, l - 1);
-				method217(8, k - 1, l);
+				removeFlag(160, k, l);
+				removeFlag(2, k, l - 1);
+				removeFlag(8, k - 1, l);
 			}
 		}
 		if (flag) {
 			if (j == 0) {
 				if (i == 0) {
-					method217(0x10000, k, l);
-					method217(4096, k - 1, l);
+					removeFlag(0x10000, k, l);
+					removeFlag(4096, k - 1, l);
 				}
 				if (i == 1) {
-					method217(1024, k, l);
-					method217(16384, k, l + 1);
+					removeFlag(1024, k, l);
+					removeFlag(16384, k, l + 1);
 				}
 				if (i == 2) {
-					method217(4096, k, l);
-					method217(0x10000, k + 1, l);
+					removeFlag(4096, k, l);
+					removeFlag(0x10000, k + 1, l);
 				}
 				if (i == 3) {
-					method217(16384, k, l);
-					method217(1024, k, l - 1);
+					removeFlag(16384, k, l);
+					removeFlag(1024, k, l - 1);
 				}
 			}
 			if (j == 1 || j == 3) {
 				if (i == 0) {
-					method217(512, k, l);
-					method217(8192, k - 1, l + 1);
+					removeFlag(512, k, l);
+					removeFlag(8192, k - 1, l + 1);
 				}
 				if (i == 1) {
-					method217(2048, k, l);
-					method217(32768, k + 1, l + 1);
+					removeFlag(2048, k, l);
+					removeFlag(32768, k + 1, l + 1);
 				}
 				if (i == 2) {
-					method217(8192, k, l);
-					method217(512, k + 1, l - 1);
+					removeFlag(8192, k, l);
+					removeFlag(512, k + 1, l - 1);
 				}
 				if (i == 3) {
-					method217(32768, k, l);
-					method217(2048, k - 1, l - 1);
+					removeFlag(32768, k, l);
+					removeFlag(2048, k - 1, l - 1);
 				}
 			}
 			if (j == 2) {
 				if (i == 0) {
-					method217(0x10400, k, l);
-					method217(4096, k - 1, l);
-					method217(16384, k, l + 1);
+					removeFlag(0x10400, k, l);
+					removeFlag(4096, k - 1, l);
+					removeFlag(16384, k, l + 1);
 				}
 				if (i == 1) {
-					method217(5120, k, l);
-					method217(16384, k, l + 1);
-					method217(0x10000, k + 1, l);
+					removeFlag(5120, k, l);
+					removeFlag(16384, k, l + 1);
+					removeFlag(0x10000, k + 1, l);
 				}
 				if (i == 2) {
-					method217(20480, k, l);
-					method217(0x10000, k + 1, l);
-					method217(1024, k, l - 1);
+					removeFlag(20480, k, l);
+					removeFlag(0x10000, k + 1, l);
+					removeFlag(1024, k, l - 1);
 				}
 				if (i == 3) {
-					method217(0x14000, k, l);
-					method217(1024, k, l - 1);
-					method217(4096, k - 1, l);
+					removeFlag(0x14000, k, l);
+					removeFlag(1024, k, l - 1);
+					removeFlag(4096, k - 1, l);
 				}
 			}
 		}
 	}
 
-	public void method216(int i, int j, int k, int l, int i1, boolean flag) {
+	public void removeObject(int i, int j, int k, int l, int i1, boolean flag) {
 		int j1 = 256;
 		if (flag) {
 			j1 += 0x20000;
 		}
-		k -= anInt290;
-		l -= anInt291;
+		k -= xInset;
+		l -= yInset;
 		if (i == 1 || i == 3) {
 			int k1 = j;
 			j = i1;
 			i1 = k1;
 		}
 		for (int l1 = k; l1 < k + j; l1++) {
-			if (l1 >= 0 && l1 < anInt292) {
+			if (l1 >= 0 && l1 < width) {
 				for (int i2 = l; i2 < l + i1; i2++) {
-					if (i2 >= 0 && i2 < anInt293) {
-						method217(j1, l1, i2);
+					if (i2 >= 0 && i2 < height) {
+						removeFlag(j1, l1, i2);
 					}
 				}
 
@@ -333,63 +333,63 @@ final class CollisionMap {
 
 	}
 
-	private void method217(int i, int j, int k) {
-		anIntArrayArray294[j][k] &= 0xffffff - i;
+	private void removeFlag(int i, int j, int k) {
+		clippingFlags[j][k] &= 0xffffff - i;
 	}
 
-	public void method218(int j, int k) {
-		k -= anInt290;
-		j -= anInt291;
-		anIntArrayArray294[k][j] &= 0xdfffff;
+	public void unblockTile(int j, int k) {
+		k -= xInset;
+		j -= yInset;
+		clippingFlags[k][j] &= 0xdfffff;
 	}
 
-	public boolean method219(int i, int j, int k, int i1, int j1, int k1) {
+	public boolean canReachWall(int i, int j, int k, int i1, int j1, int k1) {
 		if (j == i && k == k1) {
 			return true;
 		}
-		j -= anInt290;
-		k -= anInt291;
-		i -= anInt290;
-		k1 -= anInt291;
+		j -= xInset;
+		k -= yInset;
+		i -= xInset;
+		k1 -= yInset;
 		if (j1 == 0) {
 			if (i1 == 0) {
 				if (j == i - 1 && k == k1) {
 					return true;
 				}
-				if (j == i && k == k1 + 1 && (anIntArrayArray294[j][k] & 0x1280120) == 0) {
+				if (j == i && k == k1 + 1 && (clippingFlags[j][k] & 0x1280120) == 0) {
 					return true;
 				}
-				if (j == i && k == k1 - 1 && (anIntArrayArray294[j][k] & 0x1280102) == 0) {
+				if (j == i && k == k1 - 1 && (clippingFlags[j][k] & 0x1280102) == 0) {
 					return true;
 				}
 			} else if (i1 == 1) {
 				if (j == i && k == k1 + 1) {
 					return true;
 				}
-				if (j == i - 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280108) == 0) {
+				if (j == i - 1 && k == k1 && (clippingFlags[j][k] & 0x1280108) == 0) {
 					return true;
 				}
-				if (j == i + 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280180) == 0) {
+				if (j == i + 1 && k == k1 && (clippingFlags[j][k] & 0x1280180) == 0) {
 					return true;
 				}
 			} else if (i1 == 2) {
 				if (j == i + 1 && k == k1) {
 					return true;
 				}
-				if (j == i && k == k1 + 1 && (anIntArrayArray294[j][k] & 0x1280120) == 0) {
+				if (j == i && k == k1 + 1 && (clippingFlags[j][k] & 0x1280120) == 0) {
 					return true;
 				}
-				if (j == i && k == k1 - 1 && (anIntArrayArray294[j][k] & 0x1280102) == 0) {
+				if (j == i && k == k1 - 1 && (clippingFlags[j][k] & 0x1280102) == 0) {
 					return true;
 				}
 			} else if (i1 == 3) {
 				if (j == i && k == k1 - 1) {
 					return true;
 				}
-				if (j == i - 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280108) == 0) {
+				if (j == i - 1 && k == k1 && (clippingFlags[j][k] & 0x1280108) == 0) {
 					return true;
 				}
-				if (j == i + 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280180) == 0) {
+				if (j == i + 1 && k == k1 && (clippingFlags[j][k] & 0x1280180) == 0) {
 					return true;
 				}
 			}
@@ -402,14 +402,14 @@ final class CollisionMap {
 				if (j == i && k == k1 + 1) {
 					return true;
 				}
-				if (j == i + 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280180) == 0) {
+				if (j == i + 1 && k == k1 && (clippingFlags[j][k] & 0x1280180) == 0) {
 					return true;
 				}
-				if (j == i && k == k1 - 1 && (anIntArrayArray294[j][k] & 0x1280102) == 0) {
+				if (j == i && k == k1 - 1 && (clippingFlags[j][k] & 0x1280102) == 0) {
 					return true;
 				}
 			} else if (i1 == 1) {
-				if (j == i - 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280108) == 0) {
+				if (j == i - 1 && k == k1 && (clippingFlags[j][k] & 0x1280108) == 0) {
 					return true;
 				}
 				if (j == i && k == k1 + 1) {
@@ -418,14 +418,14 @@ final class CollisionMap {
 				if (j == i + 1 && k == k1) {
 					return true;
 				}
-				if (j == i && k == k1 - 1 && (anIntArrayArray294[j][k] & 0x1280102) == 0) {
+				if (j == i && k == k1 - 1 && (clippingFlags[j][k] & 0x1280102) == 0) {
 					return true;
 				}
 			} else if (i1 == 2) {
-				if (j == i - 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280108) == 0) {
+				if (j == i - 1 && k == k1 && (clippingFlags[j][k] & 0x1280108) == 0) {
 					return true;
 				}
-				if (j == i && k == k1 + 1 && (anIntArrayArray294[j][k] & 0x1280120) == 0) {
+				if (j == i && k == k1 + 1 && (clippingFlags[j][k] & 0x1280120) == 0) {
 					return true;
 				}
 				if (j == i + 1 && k == k1) {
@@ -438,10 +438,10 @@ final class CollisionMap {
 				if (j == i - 1 && k == k1) {
 					return true;
 				}
-				if (j == i && k == k1 + 1 && (anIntArrayArray294[j][k] & 0x1280120) == 0) {
+				if (j == i && k == k1 + 1 && (clippingFlags[j][k] & 0x1280120) == 0) {
 					return true;
 				}
-				if (j == i + 1 && k == k1 && (anIntArrayArray294[j][k] & 0x1280180) == 0) {
+				if (j == i + 1 && k == k1 && (clippingFlags[j][k] & 0x1280180) == 0) {
 					return true;
 				}
 				if (j == i && k == k1 - 1) {
@@ -450,75 +450,75 @@ final class CollisionMap {
 			}
 		}
 		if (j1 == 9) {
-			if (j == i && k == k1 + 1 && (anIntArrayArray294[j][k] & 0x20) == 0) {
+			if (j == i && k == k1 + 1 && (clippingFlags[j][k] & 0x20) == 0) {
 				return true;
 			}
-			if (j == i && k == k1 - 1 && (anIntArrayArray294[j][k] & 2) == 0) {
+			if (j == i && k == k1 - 1 && (clippingFlags[j][k] & 2) == 0) {
 				return true;
 			}
-			if (j == i - 1 && k == k1 && (anIntArrayArray294[j][k] & 8) == 0) {
+			if (j == i - 1 && k == k1 && (clippingFlags[j][k] & 8) == 0) {
 				return true;
 			}
-			if (j == i + 1 && k == k1 && (anIntArrayArray294[j][k] & 0x80) == 0) {
+			if (j == i + 1 && k == k1 && (clippingFlags[j][k] & 0x80) == 0) {
 				return true;
 			}
 		}
 		return false;
 	}
 
-	public boolean method220(int i, int j, int k, int l, int i1, int j1) {
+	public boolean canReachObject(int i, int j, int k, int l, int i1, int j1) {
 		if (j1 == i && k == j) {
 			return true;
 		}
-		j1 -= anInt290;
-		k -= anInt291;
-		i -= anInt290;
-		j -= anInt291;
+		j1 -= xInset;
+		k -= yInset;
+		i -= xInset;
+		j -= yInset;
 		if (l == 6 || l == 7) {
 			if (l == 7) {
 				i1 = i1 + 2 & 3;
 			}
 			if (i1 == 0) {
-				if (j1 == i + 1 && k == j && (anIntArrayArray294[j1][k] & 0x80) == 0) {
+				if (j1 == i + 1 && k == j && (clippingFlags[j1][k] & 0x80) == 0) {
 					return true;
 				}
-				if (j1 == i && k == j - 1 && (anIntArrayArray294[j1][k] & 2) == 0) {
+				if (j1 == i && k == j - 1 && (clippingFlags[j1][k] & 2) == 0) {
 					return true;
 				}
 			} else if (i1 == 1) {
-				if (j1 == i - 1 && k == j && (anIntArrayArray294[j1][k] & 8) == 0) {
+				if (j1 == i - 1 && k == j && (clippingFlags[j1][k] & 8) == 0) {
 					return true;
 				}
-				if (j1 == i && k == j - 1 && (anIntArrayArray294[j1][k] & 2) == 0) {
+				if (j1 == i && k == j - 1 && (clippingFlags[j1][k] & 2) == 0) {
 					return true;
 				}
 			} else if (i1 == 2) {
-				if (j1 == i - 1 && k == j && (anIntArrayArray294[j1][k] & 8) == 0) {
+				if (j1 == i - 1 && k == j && (clippingFlags[j1][k] & 8) == 0) {
 					return true;
 				}
-				if (j1 == i && k == j + 1 && (anIntArrayArray294[j1][k] & 0x20) == 0) {
+				if (j1 == i && k == j + 1 && (clippingFlags[j1][k] & 0x20) == 0) {
 					return true;
 				}
 			} else if (i1 == 3) {
-				if (j1 == i + 1 && k == j && (anIntArrayArray294[j1][k] & 0x80) == 0) {
+				if (j1 == i + 1 && k == j && (clippingFlags[j1][k] & 0x80) == 0) {
 					return true;
 				}
-				if (j1 == i && k == j + 1 && (anIntArrayArray294[j1][k] & 0x20) == 0) {
+				if (j1 == i && k == j + 1 && (clippingFlags[j1][k] & 0x20) == 0) {
 					return true;
 				}
 			}
 		}
 		if (l == 8) {
-			if (j1 == i && k == j + 1 && (anIntArrayArray294[j1][k] & 0x20) == 0) {
+			if (j1 == i && k == j + 1 && (clippingFlags[j1][k] & 0x20) == 0) {
 				return true;
 			}
-			if (j1 == i && k == j - 1 && (anIntArrayArray294[j1][k] & 2) == 0) {
+			if (j1 == i && k == j - 1 && (clippingFlags[j1][k] & 2) == 0) {
 				return true;
 			}
-			if (j1 == i - 1 && k == j && (anIntArrayArray294[j1][k] & 8) == 0) {
+			if (j1 == i - 1 && k == j && (clippingFlags[j1][k] & 8) == 0) {
 				return true;
 			}
-			if (j1 == i + 1 && k == j && (anIntArrayArray294[j1][k] & 0x80) == 0) {
+			if (j1 == i + 1 && k == j && (clippingFlags[j1][k] & 0x80) == 0) {
 				return true;
 			}
 		}
@@ -527,24 +527,24 @@ final class CollisionMap {
 
 	// Something to do with moving to objects/npcs etc when clicked on
 	// Maybe checking distance?
-	public boolean method221(int i, int j, int k, int l, int i1, int j1, int k1) {
+	public boolean canReachArea(int i, int j, int k, int l, int i1, int j1, int k1) {
 		int l1 = j + j1 - 1;
 		int i2 = i + l - 1;
 		if (k >= j && k <= l1 && k1 >= i && k1 <= i2) {
 			return true;
 		}
-		if (k == j - 1 && k1 >= i && k1 <= i2 && (anIntArrayArray294[k - anInt290][k1 - anInt291] & 8) == 0 && (i1 & 8) == 0) {
+		if (k == j - 1 && k1 >= i && k1 <= i2 && (clippingFlags[k - xInset][k1 - yInset] & 8) == 0 && (i1 & 8) == 0) {
 			return true;
 		}
-		if (k == l1 + 1 && k1 >= i && k1 <= i2 && (anIntArrayArray294[k - anInt290][k1 - anInt291] & 0x80) == 0 && (i1 & 2) == 0) {
+		if (k == l1 + 1 && k1 >= i && k1 <= i2 && (clippingFlags[k - xInset][k1 - yInset] & 0x80) == 0 && (i1 & 2) == 0) {
 			return true;
 		}
-		return k1 == i - 1 && k >= j && k <= l1 && (anIntArrayArray294[k - anInt290][k1 - anInt291] & 2) == 0 && (i1 & 4) == 0 || k1 == i2 + 1 && k >= j && k <= l1 && (anIntArrayArray294[k - anInt290][k1 - anInt291] & 0x20) == 0 && (i1 & 1) == 0;
+		return k1 == i - 1 && k >= j && k <= l1 && (clippingFlags[k - xInset][k1 - yInset] & 2) == 0 && (i1 & 4) == 0 || k1 == i2 + 1 && k >= j && k <= l1 && (clippingFlags[k - xInset][k1 - yInset] & 0x20) == 0 && (i1 & 1) == 0;
 	}
 
-	private final int anInt290;
-	private final int anInt291;
-	private final int anInt292;
-	private final int anInt293;
-	public final int[][] anIntArrayArray294;
+	private final int xInset;
+	private final int yInset;
+	private final int width;
+	private final int height;
+	public final int[][] clippingFlags;
 }

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -658,7 +658,7 @@ public class Game extends RSApplet {
 			worldController.initToNull();
 			System.gc();
 			for (int i = 0; i < 4; i++) {
-				aClass11Array1230[i].method210();
+				aClass11Array1230[i].reset();
 			}
 
 			for (int l = 0; l < 4; l++) {
@@ -915,7 +915,7 @@ public class Game extends RSApplet {
 						if (j3 != 22 && j3 != 29 && j3 != 34 && j3 != 36 && j3 != 46 && j3 != 47 && j3 != 48) {
 							byte byte0 = 104;
 							byte byte1 = 104;
-							int ai1[][] = aClass11Array1230[plane].anIntArrayArray294;
+							int ai1[][] = aClass11Array1230[plane].clippingFlags;
 							for (int i4 = 0; i4 < 10; i4++) {
 								int j4 = (int) (Math.random() * 4D);
 								if (j4 == 0 && k3 > 0 && k3 > k2 - 3 && (ai1[k3 - 1][l3] & 0x1280108) == 0) {
@@ -2205,7 +2205,7 @@ public class Game extends RSApplet {
 		unlinkMRUNodes();
 		worldController.initToNull();
 		for (int i = 0; i < 4; i++) {
-			aClass11Array1230[i].method210();
+			aClass11Array1230[i].reset();
 		}
 
 		System.gc();
@@ -5050,7 +5050,7 @@ public class Game extends RSApplet {
 							for (int k1 = 0; k1 < 4; k1++)
 								for (int i2 = 1; i2 < 103; i2++)
 									for (int k2 = 1; k2 < 103; k2++)
-										aClass11Array1230[k1].anIntArrayArray294[i2][k2] = 0;
+										aClass11Array1230[k1].clippingFlags[i2][k2] = 0;
 						if (inputString.equals("::clientdrop")) {
 							dropClient();
 						}
@@ -6363,7 +6363,7 @@ public class Game extends RSApplet {
 		bigY[l3++] = j1;
 		boolean flag1 = false;
 		int j4 = bigX.length;
-		int ai[][] = aClass11Array1230[plane].anIntArrayArray294;
+		int ai[][] = aClass11Array1230[plane].clippingFlags;
 		while (i4 != l3) {
 			j3 = bigX[i4];
 			k3 = bigY[i4];
@@ -6373,16 +6373,16 @@ public class Game extends RSApplet {
 				break;
 			}
 			if (i1 != 0) {
-				if ((i1 < 5 || i1 == 10) && aClass11Array1230[plane].method219(k2, j3, k3, j, i1 - 1, i2)) {
+				if ((i1 < 5 || i1 == 10) && aClass11Array1230[plane].canReachWall(k2, j3, k3, j, i1 - 1, i2)) {
 					flag1 = true;
 					break;
 				}
-				if (i1 < 10 && aClass11Array1230[plane].method220(k2, i2, k3, i1 - 1, j, j3)) {
+				if (i1 < 10 && aClass11Array1230[plane].canReachObject(k2, i2, k3, i1 - 1, j, j3)) {
 					flag1 = true;
 					break;
 				}
 			}
-			if (k1 != 0 && k != 0 && aClass11Array1230[plane].method221(i2, k2, j3, k, l1, k1, k3)) {
+			if (k1 != 0 && k != 0 && aClass11Array1230[plane].canReachArea(i2, k2, j3, k, l1, k1, k3)) {
 				flag1 = true;
 				break;
 			}
@@ -10495,7 +10495,7 @@ public class Game extends RSApplet {
 					worldController.method291(i1, j, i, (byte) -119);
 					ObjectDef class46 = ObjectDef.forID(j2);
 					if (class46.isSolid) {
-						aClass11Array1230[j].method215(l2, k2, class46.impenetrable, i1, i);
+						aClass11Array1230[j].removeWall(l2, k2, class46.impenetrable, i1, i);
 					}
 				}
 				if (j1 == 1) {
@@ -10508,14 +10508,14 @@ public class Game extends RSApplet {
 						return;
 					}
 					if (class46_1.isSolid) {
-						aClass11Array1230[j].method216(l2, class46_1.sizeX, i1, i, class46_1.sizeY, class46_1.impenetrable);
+						aClass11Array1230[j].removeObject(l2, class46_1.sizeX, i1, i, class46_1.sizeY, class46_1.impenetrable);
 					}
 				}
 				if (j1 == 3) {
 					worldController.method294(j, i, i1);
 					ObjectDef class46_2 = ObjectDef.forID(j2);
 					if (class46_2.isSolid && class46_2.interactive) {
-						aClass11Array1230[j].method218(i, i1);
+						aClass11Array1230[j].unblockTile(i, i1);
 					}
 				}
 			}

--- a/2006Scape Client/src/main/java/ObjectManager.java
+++ b/2006Scape Client/src/main/java/ObjectManager.java
@@ -41,7 +41,7 @@ final class ObjectManager {
 							k1--;
 						}
 						if (k1 >= 0) {
-							aclass11[k1].method213(i1, k);
+							aclass11[k1].blockTile(i1, k);
 						}
 					}
 				}
@@ -490,7 +490,7 @@ final class ObjectManager {
 			}
 			worldController.method280(k, k2, i, ((Animable) obj), byte0, l2, l);
 			if (class46.isSolid && class46.interactive && class11 != null) {
-				class11.method213(i, l);
+				class11.blockTile(i, l);
 			}
 			return;
 		}
@@ -540,7 +540,7 @@ final class ObjectManager {
 				}
 			}
 			if (class46.isSolid && class11 != null) {
-				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
+				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
 			}
 			return;
 		}
@@ -556,7 +556,7 @@ final class ObjectManager {
 				anIntArrayArrayArray135[k][l][i] |= 0x924;
 			}
 			if (class46.isSolid && class11 != null) {
-				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
+				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
 			}
 			return;
 		}
@@ -602,7 +602,7 @@ final class ObjectManager {
 				}
 			}
 			if (class46.isSolid && class11 != null) {
-				class11.method211(i, j1, l, j, class46.impenetrable);
+				class11.addWall(i, j1, l, j, class46.impenetrable);
 			}
 			if (class46.anInt775 != 16) {
 				worldController.method290(i, class46.anInt775, l, k);
@@ -629,7 +629,7 @@ final class ObjectManager {
 				}
 			}
 			if (class46.isSolid && class11 != null) {
-				class11.method211(i, j1, l, j, class46.impenetrable);
+				class11.addWall(i, j1, l, j, class46.impenetrable);
 			}
 			return;
 		}
@@ -661,7 +661,7 @@ final class ObjectManager {
 				}
 			}
 			if (class46.isSolid && class11 != null) {
-				class11.method211(i, j1, l, j, class46.impenetrable);
+				class11.addWall(i, j1, l, j, class46.impenetrable);
 			}
 			if (class46.anInt775 != 16) {
 				worldController.method290(i, class46.anInt775, l, k);
@@ -688,7 +688,7 @@ final class ObjectManager {
 				}
 			}
 			if (class46.isSolid && class11 != null) {
-				class11.method211(i, j1, l, j, class46.impenetrable);
+				class11.addWall(i, j1, l, j, class46.impenetrable);
 			}
 			return;
 		}
@@ -701,7 +701,7 @@ final class ObjectManager {
 			}
 			worldController.method284(l2, byte0, k2, 1, ((Animable) obj6), 1, k, 0, i, l);
 			if (class46.isSolid && class11 != null) {
-				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
+				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
 			}
 			return;
 		}
@@ -828,7 +828,7 @@ final class ObjectManager {
 		for (int i2 = 0; i2 < 8; i2++) {
 			for (int j2 = 0; j2 < 8; j2++) {
 				if (l + i2 > 0 && l + i2 < 103 && l1 + j2 > 0 && l1 + j2 < 103) {
-					aclass11[k1].anIntArrayArray294[l + i2][l1 + j2] &= 0xfeffffff;
+					aclass11[k1].clippingFlags[l + i2][l1 + j2] &= 0xfeffffff;
 				}
 			}
 
@@ -855,7 +855,7 @@ final class ObjectManager {
 			for (int j1 = 0; j1 < 64; j1++) {
 				for (int k1 = 0; k1 < 64; k1++) {
 					if (j + j1 > 0 && j + j1 < 103 && i + k1 > 0 && i + k1 < 103) {
-						aclass11[i1].anIntArrayArray294[j + j1][i + k1] &= 0xfeffffff;
+						aclass11[i1].clippingFlags[j + j1][i + k1] &= 0xfeffffff;
 					}
 				}
 
@@ -1051,7 +1051,7 @@ final class ObjectManager {
 			}
 			worldController.method280(k1, l2, j, ((Animable) obj), byte1, i3, i1);
 			if (class46.isSolid && class46.interactive) {
-				class11.method213(j, i1);
+				class11.blockTile(j, i1);
 			}
 			return;
 		}
@@ -1079,7 +1079,7 @@ final class ObjectManager {
 				worldController.method284(i3, byte1, l2, i5, ((Animable) obj1), k4, k1, j5, j, i1);
 			}
 			if (class46.isSolid) {
-				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
+				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
 			}
 			return;
 		}
@@ -1092,7 +1092,7 @@ final class ObjectManager {
 			}
 			worldController.method284(i3, byte1, l2, 1, ((Animable) obj2), 1, k1, 0, j, i1);
 			if (class46.isSolid) {
-				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
+				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
 			}
 			return;
 		}
@@ -1105,7 +1105,7 @@ final class ObjectManager {
 			}
 			worldController.method282(anIntArray152[i], ((Animable) obj3), i3, j, byte1, i1, null, l2, 0, k1);
 			if (class46.isSolid) {
-				class11.method211(j, i, i1, k, class46.impenetrable);
+				class11.addWall(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
@@ -1118,7 +1118,7 @@ final class ObjectManager {
 			}
 			worldController.method282(anIntArray140[i], ((Animable) obj4), i3, j, byte1, i1, null, l2, 0, k1);
 			if (class46.isSolid) {
-				class11.method211(j, i, i1, k, class46.impenetrable);
+				class11.addWall(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
@@ -1135,7 +1135,7 @@ final class ObjectManager {
 			}
 			worldController.method282(anIntArray152[i], ((Animable) obj11), i3, j, byte1, i1, ((Animable) obj12), l2, anIntArray152[j3], k1);
 			if (class46.isSolid) {
-				class11.method211(j, i, i1, k, class46.impenetrable);
+				class11.addWall(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
@@ -1148,7 +1148,7 @@ final class ObjectManager {
 			}
 			worldController.method282(anIntArray140[i], ((Animable) obj5), i3, j, byte1, i1, null, l2, 0, k1);
 			if (class46.isSolid) {
-				class11.method211(j, i, i1, k, class46.impenetrable);
+				class11.addWall(j, i, i1, k, class46.impenetrable);
 			}
 			return;
 		}
@@ -1161,7 +1161,7 @@ final class ObjectManager {
 			}
 			worldController.method284(i3, byte1, l2, 1, ((Animable) obj6), 1, k1, 0, j, i1);
 			if (class46.isSolid) {
-				class11.method212(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
+				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
 			}
 			return;
 		}


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

> **PR Title format**: `[BOT] <type(scope)>: <summary>`

## ✅ Pre-flight Checklist
| Item | Status |
| --- | --- |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes | N/A |
| ≥ 80 % coverage on touched lines | N/A |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why
Cleaned up obfuscated method and field names in `CollisionMap` for readability. Updated all call sites accordingly.

## 🗂️ Detailed Changes
- Renamed internal API of `CollisionMap`
- Updated `Game` and `ObjectManager` to use new names

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| `method210` | `reset` |
| `method211` | `addWall` |
| `method212` | `addObject` |
| `method213` | `blockTile` |
| `method214` | `addFlag` |
| `method215` | `removeWall` |
| `method216` | `removeObject` |
| `method217` | `removeFlag` |
| `method218` | `unblockTile` |
| `method219` | `canReachWall` |
| `method220` | `canReachObject` |
| `method221` | `canReachArea` |
| `anInt290` | `xInset` |
| `anInt291` | `yInset` |
| `anInt292` | `width` |
| `anInt293` | `height` |
| `anIntArrayArray294` | `clippingFlags` |

- **Batch**:
- **Revert command**: `git revert -m 1 ac82bb8ec6f065a08430772c365223224993754c`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/CollisionMap.java  | 410 +++++++++++-----------
 2006Scape Client/src/main/java/Game.java          |  22 +-
 2006Scape Client/src/main/java/ObjectManager.java |  38 +-
 3 files changed, 235 insertions(+), 235 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded with warnings:
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
...
3 warnings
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, run the revert command above.

------
https://chatgpt.com/codex/tasks/task_e_686423e01430832b9ce3c3746b1a0164