### PR TITLE
[BOT] refactor(rename): method525 → decodeChatMessage

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -4911,7 +4911,7 @@ public class Game extends RSApplet {
 						stream.writeWordBigEndian(0);
 						int k = stream.currentOffset;
 						stream.writeQWord(aLong953);
-						TextInput.method526(promptInput, stream);
+                                                TextInput.encodeChatMessage(promptInput, stream);
 						stream.writeBytes(stream.currentOffset - k);
 						promptInput = TextInput.processText(promptInput);
 						promptInput = Censor.doCensor(promptInput);
@@ -5171,7 +5171,7 @@ public class Game extends RSApplet {
                                                 stream.writeByteSub(i3);
                                                 stream.writeByteSub(j2);
 						aStream_834.currentOffset = 0;
-						TextInput.method526(inputString, aStream_834);
+                                                TextInput.encodeChatMessage(inputString, aStream_834);
 						stream.writeBytesReverseAdd(0, aStream_834.buffer, aStream_834.currentOffset);
 						stream.writeBytes(stream.currentOffset - j3);
 						inputString = TextInput.processText(inputString);
@@ -8621,7 +8621,7 @@ public class Game extends RSApplet {
 						aStream_834.currentOffset = 0;
 						stream.readBytesReverse(j3, 0, aStream_834.buffer);
 						aStream_834.currentOffset = 0;
-						String s = TextInput.method525(j3, aStream_834);
+                                                String s = TextInput.decodeChatMessage(j3, aStream_834);
 						s = Censor.doCensor(s);
 						player.textSpoken = s;
 						player.anInt1513 = i1 >> 8;
@@ -11388,7 +11388,7 @@ public class Game extends RSApplet {
 				if (!flag5 && restrictedArea == 0) {
 					try {
 						// Direct message
-						String s9 = TextInput.method525(pktSize - 13, inStream);
+                                                String s9 = TextInput.decodeChatMessage(pktSize - 13, inStream);
 						if (l21 == 2 || l21 == 3) {
 							pushMessage(s9, 7, "@cr2@" + TextClass.fixName(TextClass.nameForLong(l5)));
 						} else if (l21 == 1) {

--- a/2006Scape Client/src/main/java/TextInput.java
+++ b/2006Scape Client/src/main/java/TextInput.java
@@ -4,7 +4,7 @@
 
 final class TextInput {
 
-	public static String method525(int i, Stream stream) {
+        public static String decodeChatMessage(int i, Stream stream) {
 		int j = 0;
 		int k = -1;
 		for (int l = 0; l < i; l++) {
@@ -12,42 +12,42 @@ final class TextInput {
 			int j1 = i1 >> 4 & 0xf;
 			if (k == -1) {
 				if (j1 < 13) {
-					aCharArray631[j++] = validChars[j1];
+                                        charBuffer[j++] = validChars[j1];
 				} else {
 					k = j1;
 				}
 			} else {
-				aCharArray631[j++] = validChars[(k << 4) + j1 - 195];
+                                charBuffer[j++] = validChars[(k << 4) + j1 - 195];
 				k = -1;
 			}
 			j1 = i1 & 0xf;
 			if (k == -1) {
 				if (j1 < 13) {
-					aCharArray631[j++] = validChars[j1];
+                                        charBuffer[j++] = validChars[j1];
 				} else {
 					k = j1;
 				}
 			} else {
-				aCharArray631[j++] = validChars[(k << 4) + j1 - 195];
+                                charBuffer[j++] = validChars[(k << 4) + j1 - 195];
 				k = -1;
 			}
 		}
 
 		boolean flag1 = true;
 		for (int k1 = 0; k1 < j; k1++) {
-			char c = aCharArray631[k1];
+                        char c = charBuffer[k1];
 			if (flag1 && c >= 'a' && c <= 'z') {
-				aCharArray631[k1] += '\uFFE0';
+                                charBuffer[k1] += '\uFFE0';
 				flag1 = false;
 			}
 			if (c == '.' || c == '!' || c == '?') {
 				flag1 = true;
 			}
 		}
-		return new String(aCharArray631, 0, j);
-	}
+                return new String(charBuffer, 0, j);
+        }
 
-	public static void method526(String s, Stream stream) {
+        public static void encodeChatMessage(String s, Stream stream) {
 		if (s.length() > 80) {
 			s = s.substring(0, 80);
 		}
@@ -88,14 +88,14 @@ final class TextInput {
 
 	public static String processText(String s) {
 		stream.currentOffset = 0;
-		method526(s, stream);
+                encodeChatMessage(s, stream);
 		int j = stream.currentOffset;
 		stream.currentOffset = 0;
-		String s1 = method525(j, stream);
+                String s1 = decodeChatMessage(j, stream);
 		return s1;
 	}
 
-	private static final char[] aCharArray631 = new char[100];
+        private static final char[] charBuffer = new char[100];
 	private static final Stream stream = new Stream(new byte[100]);
 	private static final char[] validChars = {' ', 'e', 't', 'a', 'o', 'i', 'h', 'n', 's', 'r', 'd', 'l', 'u', 'm', 'w', 'c', 'y', 'f', 'g', 'p', 'b', 'v', 'k', 'x', 'j', 'q', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ' ', '!', '?', '.', ',', ':', ';', '(', ')', '-', '&', '*', '\\', '\'', '@', '#', '+', '=', '\243', '$', '%', '"', '[', ']'};
 


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item | Status |
| --- | --- |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes | ❌ |
| ≥ 80 % coverage on touched lines | ❌ |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why
Renames obfuscated chat encoding methods in `TextInput` for clarity.

## 🗂️ Detailed Changes
- `method525` → `decodeChatMessage`
- `method526` → `encodeChatMessage`
- `aCharArray631` → `charBuffer`
- Updated references in `Game.java`

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| --- | --- |
| `method525` | `decodeChatMessage` |
| `method526` | `encodeChatMessage` |
| `aCharArray631` | `charBuffer` |

- **Batch**: single
- **Revert command**: `git revert -m 1 4dc1f077`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java      |  8 ++++----
 2006Scape Client/src/main/java/TextInput.java | 26 +++++++++++++-------------
 2 files changed, 17 insertions(+), 17 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeds using the repository command:
```text
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
2006Scape Client/src/main/java/Game.java:2767: warning: [removal] AppletContext in java.applet has been deprecated and marked for removal
        public AppletContext getAppletContext() {
               ^
2006Scape Client/src/main/java/Signlink.java:392: warning: [removal] Applet in java.applet has been deprecated and marked for removal
        public static Applet mainapp = null;
                      ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: 2006Scape Client/src/main/java/RSApplet.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
3 warnings
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of AGENTS.md applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_686500f036d4832b9115a71e067f0a84