### PR TITLE
[BOT] refactor(rename): method548 → requestModel

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -838,11 +838,11 @@ public class Game extends RSApplet {
 		for (int l3 = k; l3 <= j1; l3++) {
 			for (int j5 = i2; j5 <= l2; j5++) {
 				if (l3 == k || l3 == j1 || j5 == i2 || j5 == l2) {
-                                        int j7 = onDemandFetcher.method562(0, j5, l3);
+                                        int j7 = onDemandFetcher.getRegionArchiveId(0, j5, l3);
                                         if (j7 != -1) {
                                                 onDemandFetcher.requestFileNow(j7, 3);
                                         }
-                                        int k8 = onDemandFetcher.method562(1, j5, l3);
+                                        int k8 = onDemandFetcher.getRegionArchiveId(1, j5, l3);
                                         if (k8 != -1) {
                                                 onDemandFetcher.requestFileNow(k8, 3);
                                         }
@@ -7037,7 +7037,7 @@ public class Game extends RSApplet {
 						Thread.sleep(100L);
 					} catch (Exception _ex) {
 					}
-					if (onDemandFetcher.anInt1349 > 3) {
+                                        if (onDemandFetcher.socketErrorCount > 3) {
 						loadError();
 						return;
 					}
@@ -7059,7 +7059,7 @@ public class Game extends RSApplet {
 					Thread.sleep(100L);
 				} catch (Exception _ex) {
 				}
-				if (onDemandFetcher.anInt1349 > 3) {
+                                if (onDemandFetcher.socketErrorCount > 3) {
 					loadError();
 					return;
 				}
@@ -7087,18 +7087,18 @@ public class Game extends RSApplet {
 			}
 			if (decompressors[0] != null) {
 				drawLoadingText(75, "Requesting maps");
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(0, 48, 47));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(1, 48, 47));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(0, 48, 48));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(1, 48, 48));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(0, 48, 49));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(1, 48, 49));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(0, 47, 47));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(1, 47, 47));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(0, 47, 48));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(1, 47, 48));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(0, 148, 48));
-                                onDemandFetcher.queueRequest(3, onDemandFetcher.method562(1, 148, 48));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(0, 48, 47));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(1, 48, 47));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(0, 48, 48));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(1, 48, 48));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(0, 48, 49));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(1, 48, 49));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(0, 47, 47));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(1, 47, 47));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(0, 47, 48));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(1, 47, 48));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(0, 148, 48));
+                                onDemandFetcher.queueRequest(3, onDemandFetcher.getRegionArchiveId(1, 148, 48));
 				k = onDemandFetcher.getNodeCount();
 				while (onDemandFetcher.getNodeCount() > 0) {
 					int j2 = k - onDemandFetcher.getNodeCount();
@@ -10888,11 +10888,11 @@ public class Game extends RSApplet {
 								anIntArray1236[k16] = -1;
 								k16++;
 							} else {
-                                                                int k28 = anIntArray1235[k16] = onDemandFetcher.method562(0, j26, l23);
+                                                                int k28 = anIntArray1235[k16] = onDemandFetcher.getRegionArchiveId(0, j26, l23);
                                                                 if (k28 != -1) {
                                                                         onDemandFetcher.queueRequest(3, k28);
                                                                 }
-                                                                int j30 = anIntArray1236[k16] = onDemandFetcher.method562(1, j26, l23);
+                                                                int j30 = anIntArray1236[k16] = onDemandFetcher.getRegionArchiveId(1, j26, l23);
                                                                 if (j30 != -1) {
                                                                         onDemandFetcher.queueRequest(3, j30);
                                                                 }
@@ -10941,11 +10941,11 @@ public class Game extends RSApplet {
 						int i29 = anIntArray1234[l26] = ai[l26];
 						int l30 = i29 >> 8 & 0xff;
 						int l31 = i29 & 0xff;
-                                                int j32 = anIntArray1235[l26] = onDemandFetcher.method562(0, l31, l30);
+                                                int j32 = anIntArray1235[l26] = onDemandFetcher.getRegionArchiveId(0, l31, l30);
                                                 if (j32 != -1) {
                                                         onDemandFetcher.queueRequest(3, j32);
                                                 }
-                                                int i33 = anIntArray1236[l26] = onDemandFetcher.method562(1, l31, l30);
+                                                int i33 = anIntArray1236[l26] = onDemandFetcher.getRegionArchiveId(1, l31, l30);
                                                 if (i33 != -1) {
                                                         onDemandFetcher.queueRequest(3, i33);
                                                 }

--- a/2006Scape Client/src/main/java/Model.java
+++ b/2006Scape Client/src/main/java/Model.java
@@ -115,7 +115,7 @@ public final class Model extends Animable {
 		}
 		ModelHeader header = modelHeaders.length < j  ? null : modelHeaders[j];
 		if (header == null) {
-			modelFetcher.method548(j);
+                        modelFetcher.requestModel(j);
 			return null;
 		} else {
 			return new Model(j);
@@ -128,7 +128,7 @@ public final class Model extends Animable {
 		}
 		ModelHeader header = modelHeaders[i];
 		if (header == null) {
-			modelFetcher.method548(i);
+                        modelFetcher.requestModel(i);
 			return false;
 		} else {
 			return true;

--- a/2006Scape Client/src/main/java/OnDemandFetcher.java
+++ b/2006Scape Client/src/main/java/OnDemandFetcher.java
@@ -256,8 +256,8 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 				ioBuffer[3] = 0;
 			}
 			outputStream.write(ioBuffer, 0, 4);
-			writeLoopCycle = 0;
-			anInt1349 = -10000;
+                        writeLoopCycle = 0;
+                        socketErrorCount = -10000;
 			return;
 		} catch (IOException ioexception) {
 		}
@@ -268,8 +268,8 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 		socket = null;
 		inputStream = null;
 		outputStream = null;
-		expectedSize = 0;
-		anInt1349++;
+                expectedSize = 0;
+                socketErrorCount++;
 	}
 
 	public int getAnimCount() {
@@ -412,10 +412,10 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 		onDemandData.dataType = j;
 		onDemandData.ID = i;
 		onDemandData.incomplete = false;
-		synchronized (aClass19_1344) {
-			aClass19_1344.insertHead(onDemandData);
-		}
-	}
+                synchronized (requestedQueue) {
+                        requestedQueue.insertHead(onDemandData);
+                }
+        }
 
 	public OnDemandData getNextNode() {
 		OnDemandData onDemandData;
@@ -453,11 +453,11 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 		return onDemandData;
 	}
 
-        public int method562(int i, int k, int l) {
-                int i1 = (l << 8) + k;
+        public int getRegionArchiveId(int type, int regionX, int regionY) {
+                int i1 = (regionY << 8) + regionX;
                 for (int j1 = 0; j1 < regionIds.length; j1++) {
                         if (regionIds[j1] == i1) {
-                                if (i == 0) {
+                                if (type == 0) {
                                         return mapArchiveIds[j1];
                                 } else {
                                         return landArchiveIds[j1];
@@ -468,9 +468,9 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
         }
 
         @Override
-        public void method548(int i) {
-                queueRequest(0, i);
-	}
+        public void requestModel(int modelId) {
+                queueRequest(0, modelId);
+        }
 
         public void validateOrQueue(byte byte0, int i, int j) {
 		if (clientInstance.decompressors[0] == null) {
@@ -527,8 +527,8 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 	}
 
         public void clearPriorityQueue() {
-                synchronized (aClass19_1344) {
-                        aClass19_1344.removeAll();
+                synchronized (requestedQueue) {
+                        requestedQueue.removeAll();
                 }
         }
 
@@ -565,11 +565,11 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
                         if (currentPriority == 0) {
 				break;
 			}
-			OnDemandData onDemandData;
-			synchronized (aClass19_1344) {
-				onDemandData = (OnDemandData) aClass19_1344.popHead();
-			}
-			while (onDemandData != null) {
+                        OnDemandData onDemandData;
+                        synchronized (requestedQueue) {
+                                onDemandData = (OnDemandData) requestedQueue.popHead();
+                        }
+                        while (onDemandData != null) {
 				if (fileStatus[onDemandData.dataType][onDemandData.ID] != 0) {
 					fileStatus[onDemandData.dataType][onDemandData.ID] = 0;
 					requested.insertHead(onDemandData);
@@ -584,10 +584,10 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 						return;
 					}
 				}
-				synchronized (aClass19_1344) {
-					onDemandData = (OnDemandData) aClass19_1344.popHead();
-				}
-			}
+                                synchronized (requestedQueue) {
+                                        onDemandData = (OnDemandData) requestedQueue.popHead();
+                                }
+                        }
 			for (int j = 0; j < 4; j++) {
 				byte abyte0[] = fileStatus[j];
 				int k = abyte0.length;
@@ -627,8 +627,8 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 		statusString = "";
 		crc32 = new CRC32();
 		ioBuffer = new byte[500];
-		fileStatus = new byte[4][];
-		aClass19_1344 = new NodeList();
+                fileStatus = new byte[4][];
+                requestedQueue = new NodeList();
 		running = true;
 		waiting = false;
 		aClass19_1358 = new NodeList();
@@ -652,11 +652,11 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 	public int onDemandCycle;
 	private final byte[][] fileStatus;
 	private Game clientInstance;
-	private final NodeList aClass19_1344;
+        private final NodeList requestedQueue;
 	private int completedSize;
 	private int expectedSize;
 	int[] anIntArray1348;
-	public int anInt1349;
+        public int socketErrorCount;
         private int[] mapArchiveIds;
 	private int filesLoaded;
 	private boolean running;

--- a/2006Scape Client/src/main/java/OnDemandFetcherParent.java
+++ b/2006Scape Client/src/main/java/OnDemandFetcherParent.java
@@ -4,8 +4,8 @@
 
 public class OnDemandFetcherParent {
 
-	public void method548(int i) {
-	}
+    public void requestModel(int i) {
+    }
 
 	OnDemandFetcherParent() {
 	}


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) |        |
| `spotbugs:check` passes             |        |
| ≥ 80 % coverage on touched lines    |        |
| Net Δ lines < 5 000                 |        |
| ≤ 10 files modified                 |   ✅   |
| Branch rebased onto latest `main`   |        |
| PR labeled `bot`                    |   ✅   |
| No new external dependencies        |   ✅   |

---

## 🔍 What & Why
Renamed several poorly named members in `OnDemandFetcher` for clarity. This keeps behaviour the same while improving readability.

---

## 🗂️ Detailed Changes
- renamed `method548` → `requestModel`
- renamed `method562` → `getRegionArchiveId`
- renamed `anInt1349` → `socketErrorCount`
- renamed `aClass19_1344` → `requestedQueue`
- updated all references and usages

---

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| method548 | requestModel |
| method562 | getRegionArchiveId |
| anInt1349 | socketErrorCount |
| aClass19_1344 | requestedQueue |

- **Batch**: 
- **Revert command**: `git revert -m 1 311be76a`

---

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java           | 40 +++++++--------
 2006Scape Client/src/main/java/Model.java          |  4 +-
 2006Scape Client/src/main/java/OnDemandFetcher.java | 58 +++++++++++-----------
 2006Scape Client/src/main/java/OnDemandFetcherParent.java | 4 +-
 4 files changed, 53 insertions(+), 53 deletions(-)
```

---

## 🧪 Integration-Test Log
Compilation succeeds with warnings using JDK 17.
```
$ git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac
```

---

## 📝 Rollback Plan
Use the revert command above if issues occur.


------
https://chatgpt.com/codex/tasks/task_e_68650978dafc832b934bbf621c9005c4