### PR TITLE
[BOT] refactor(rename): method206 -> getModelForMedia

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -5422,9 +5422,9 @@ public class Game extends RSApplet {
 				model.buildVertexGroups();
 				model.applyFrame(Animation.anims[myPlayer.anInt1511].anIntArray353[0]);
 				model.applyLighting(64, 850, -30, -50, -30, true);
-				class9.anInt233 = 5;
-				class9.mediaID = 0;
-				RSInterface.method208(model, 0, 5);
+                                class9.mediaType = 5;
+                                class9.mediaId = 0;
+                                RSInterface.clearModelCache(model, 0, 5);
 			}
 			return;
 		}
@@ -8448,10 +8448,10 @@ public class Game extends RSApplet {
 					}
 					Model model;
 					if (i7 == -1) {
-						model = component.method209(-1, -1, flag2);
+                                                model = component.prepareModel(-1, -1, flag2);
 					} else {
 						Animation animation = Animation.anims[i7];
-						model = component.method209(animation.anIntArray354[component.anInt246], animation.anIntArray353[component.anInt246], flag2);
+                                                model = component.prepareModel(animation.anIntArray354[component.anInt246], animation.anIntArray353[component.anInt246], flag2);
 					}
 					if (model != null) {
 						model.method482(component.anInt271, 0, component.anInt270, 0, i5, l5);
@@ -10691,11 +10691,11 @@ public class Game extends RSApplet {
 			}
 			if (pktType == 185) {
 				int k = inStream.readShortLEAdd();
-				RSInterface.interfaceCache[k].anInt233 = 3;
+                                RSInterface.interfaceCache[k].mediaType = 3;
 				if (myPlayer.desc == null) {
-					RSInterface.interfaceCache[k].mediaID = (myPlayer.anIntArray1700[0] << 25) + (myPlayer.anIntArray1700[4] << 20) + (myPlayer.equipment[0] << 15) + (myPlayer.equipment[8] << 10) + (myPlayer.equipment[11] << 5) + myPlayer.equipment[1];
+                                        RSInterface.interfaceCache[k].mediaId = (myPlayer.anIntArray1700[0] << 25) + (myPlayer.anIntArray1700[4] << 20) + (myPlayer.equipment[0] << 15) + (myPlayer.equipment[8] << 10) + (myPlayer.equipment[11] << 5) + myPlayer.equipment[1];
 				} else {
-					RSInterface.interfaceCache[k].mediaID = (int) (0x12345678L + myPlayer.desc.type);
+                                        RSInterface.interfaceCache[k].mediaId = (int) (0x12345678L + myPlayer.desc.type);
 				}
 				pktType = -1;
 				return true;
@@ -11048,8 +11048,8 @@ public class Game extends RSApplet {
 			if (pktType == 75) {
 				int j3 = inStream.readShortLEAdd();
 				int j11 = inStream.readShortLEAdd();
-				RSInterface.interfaceCache[j11].anInt233 = 2;
-				RSInterface.interfaceCache[j11].mediaID = j3;
+                                RSInterface.interfaceCache[j11].mediaType = 2;
+                                RSInterface.interfaceCache[j11].mediaId = j3;
 				pktType = -1;
 				return true;
 			}
@@ -11426,14 +11426,14 @@ public class Game extends RSApplet {
 				int i6 = inStream.readShortLE();
 				int i13 = inStream.readUnsignedWord();
 				int k18 = inStream.readUnsignedWord();
-				if (k18 == 0x00ffff) {
-					RSInterface.interfaceCache[i6].anInt233 = 0;
+                                if (k18 == 0x00ffff) {
+                                        RSInterface.interfaceCache[i6].mediaType = 0;
 					pktType = -1;
 					return true;
 				} else {
 					ItemDef itemDef = ItemDef.lookup(k18);
-					RSInterface.interfaceCache[i6].anInt233 = 4;
-					RSInterface.interfaceCache[i6].mediaID = k18;
+                                        RSInterface.interfaceCache[i6].mediaType = 4;
+                                        RSInterface.interfaceCache[i6].mediaId = k18;
 					RSInterface.interfaceCache[i6].anInt270 = itemDef.modelRotation1;
 					RSInterface.interfaceCache[i6].anInt271 = itemDef.modelRotation2;
 					RSInterface.interfaceCache[i6].anInt269 = itemDef.modelZoom * 100 / i13;
@@ -11532,8 +11532,8 @@ public class Game extends RSApplet {
 			if (pktType == 8) {
 				int k6 = inStream.readShortLEAdd();
 				int l13 = inStream.readUnsignedWord();
-				RSInterface.interfaceCache[k6].anInt233 = 1;
-				RSInterface.interfaceCache[k6].mediaID = l13;
+                                RSInterface.interfaceCache[k6].mediaType = 1;
+                                RSInterface.interfaceCache[k6].mediaId = l13;
 				pktType = -1;
 				return true;
 			}

--- a/2006Scape Client/src/main/java/RSInterface.java
+++ b/2006Scape Client/src/main/java/RSInterface.java
@@ -10,7 +10,7 @@ public final class RSInterface {
 	}
 	
 	public static void unpack(StreamLoader streamLoader, TextDrawingArea textDrawingAreas[], StreamLoader streamLoader_1) {
-		aMRUNodes_238 = new MRUNodes(50000);
+               spriteCache = new MRUNodes(50000);
 		Stream stream = new Stream(streamLoader.getDataForName("data"));
 		int i = -1;
 		int j = stream.readUnsignedWord();
@@ -97,7 +97,7 @@ public final class RSInterface {
 						String s1 = stream.readString();
 						if (streamLoader_1 != null && s1.length() > 0) {
 							int i5 = s1.lastIndexOf(",");
-							rsInterface.sprites[j2] = method207(Integer.parseInt(s1.substring(i5 + 1)), streamLoader_1, s1.substring(0, i5));
+                                    rsInterface.sprites[j2] = loadSprite(Integer.parseInt(s1.substring(i5 + 1)), streamLoader_1, s1.substring(0, i5));
 						}
 					}
 				}
@@ -145,19 +145,19 @@ public final class RSInterface {
 				String s = stream.readString();
 				if (streamLoader_1 != null && s.length() > 0) {
 					int i4 = s.lastIndexOf(",");
-					rsInterface.sprite1 = method207(Integer.parseInt(s.substring(i4 + 1)), streamLoader_1, s.substring(0, i4));
+                                    rsInterface.sprite1 = loadSprite(Integer.parseInt(s.substring(i4 + 1)), streamLoader_1, s.substring(0, i4));
 				}
 				s = stream.readString();
 				if (streamLoader_1 != null && s.length() > 0) {
 					int j4 = s.lastIndexOf(",");
-					rsInterface.sprite2 = method207(Integer.parseInt(s.substring(j4 + 1)), streamLoader_1, s.substring(0, j4));
+                                    rsInterface.sprite2 = loadSprite(Integer.parseInt(s.substring(j4 + 1)), streamLoader_1, s.substring(0, j4));
 				}
 			}
 			if (rsInterface.type == 6) {
 				int l = stream.readUnsignedByte();
 				if (l != 0) {
-					rsInterface.anInt233 = 1;
-					rsInterface.mediaID = (l - 1 << 8) + stream.readUnsignedByte();
+                                        rsInterface.mediaType = 1;
+                                        rsInterface.mediaId = (l - 1 << 8) + stream.readUnsignedByte();
 				}
 				l = stream.readUnsignedByte();
 				if (l != 0) {
@@ -228,17 +228,17 @@ public final class RSInterface {
 				}
 			}
 		}
-		aMRUNodes_238 = null;
+               spriteCache = null;
 	}
 
-	private Model method206(int i, int j) {
+    private Model getModelForMedia(int i, int j) {
 		ItemDef itemDefinition = null;
 		if (type == 4) {
 			itemDefinition = ItemDef.lookup(id);
                        lightness += itemDefinition.ambient;
                        shading += itemDefinition.contrast;
 		}
-		Model model = (Model) aMRUNodes_264.insertFromCache((i << 16) + j);
+                Model model = (Model) modelCache.insertFromCache((i << 16) + j);
 		if (model != null)
 			return model;
 		if (i == 1)
@@ -252,19 +252,19 @@ public final class RSInterface {
 		if (i == 5)
 			model = null;
 		if (model != null)
-			aMRUNodes_264.removeFromCache(model, (i << 16) + j);
+                        modelCache.removeFromCache(model, (i << 16) + j);
 		return model;
 	}
 
-	private static Sprite method207(int i, StreamLoader streamLoader, String s) {
+    private static Sprite loadSprite(int i, StreamLoader streamLoader, String s) {
 		long l = (TextClass.method585(s) << 8) + i;
-		Sprite sprite = (Sprite) aMRUNodes_238.insertFromCache(l);
+                Sprite sprite = (Sprite) spriteCache.insertFromCache(l);
 		if (sprite != null) {
 			return sprite;
 		}
 		try {
 			sprite = new Sprite(streamLoader, s, i);
-			aMRUNodes_238.removeFromCache(sprite, l);
+                        spriteCache.removeFromCache(sprite, l);
 		} catch (Exception _ex) {
 			return null;
 		}
@@ -282,21 +282,21 @@ public final class RSInterface {
 
 	}
 
-	public static void method208(Model model, int id, int type) {
-		aMRUNodes_264.unlinkAll();
-		if (model != null && type != 4) {
-			aMRUNodes_264.removeFromCache(model, (type << 16) + id);
-		}
-	}
+        public static void clearModelCache(Model model, int id, int type) {
+                modelCache.unlinkAll();
+                if (model != null && type != 4) {
+                        modelCache.removeFromCache(model, (type << 16) + id);
+                }
+        }
 
-	public Model method209(int j, int k, boolean flag) {
+        public Model prepareModel(int j, int k, boolean flag) {
 		lightness = 64;
 		shading = 768;
 		Model model;
 		if (flag) {
-			model = method206(anInt255, anInt256);
+                        model = getModelForMedia(anInt255, anInt256);
 		} else {
-			model = method206(anInt233, mediaID);
+                        model = getModelForMedia(mediaType, mediaId);
 		}
 		if (model == null) {
 			return null;
@@ -344,12 +344,12 @@ public final class RSInterface {
 	public int anInt230;
 	public int invSpritePadX;
 	public int textColor;
-	public int anInt233;
-	public int mediaID;
+        public int mediaType;
+        public int mediaId;
 	public boolean aBoolean235;
 	public int parentID;
 	public int spellUsableOn;
-	private static MRUNodes aMRUNodes_238;
+        private static MRUNodes spriteCache;
 	public int anInt239;
 	public int children[];
 	public int childX[];
@@ -374,7 +374,7 @@ public final class RSInterface {
 	public int scrollMax;
 	public int type;
 	public int anInt263;
-	private static final MRUNodes aMRUNodes_264 = new MRUNodes(30);
+        private static final MRUNodes modelCache = new MRUNodes(30);
 	public int anInt265;
 	public boolean aBoolean266;
 	public int height;


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Renamed several obfuscated fields and methods within `RSInterface` to improve readability. All references in other classes were updated accordingly.

## 🗂️ Detailed Changes
- Renamed model and sprite cache fields.
- Renamed media-related fields.
- Renamed helper methods handling models and sprites.
- Updated all usages across `Game`.

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| method206 | getModelForMedia |
| method207 | loadSprite |
| method208 | clearModelCache |
| method209 | prepareModel |
| aMRUNodes_238 | spriteCache |
| aMRUNodes_264 | modelCache |
| anInt233 | mediaType |
| mediaID | mediaId |

- **Batch**: 1
- **Revert command**: `git revert -m 1 c57c05ad`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java        | 32 +++++++--------
 2006Scape Client/src/main/java/RSInterface.java | 52 ++++++++++++-------------
 2 files changed, 42 insertions(+), 42 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded using `javac`.

## 📝 Rollback Plan
Use the revert command above if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68650d38e230832baec44805668a51b5