### PR TITLE
[BOT] refactor(rename): method585 → hashSpriteName

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -10646,8 +10646,8 @@ public class Game extends RSApplet {
 				membersInt = inStream.readUnsignedByte();
 				anInt1193 = inStream.readIntV2();
 				daysSinceLastLogin = inStream.readUnsignedWord();
-				if (anInt1193 != 0 && openInterfaceID == -1) {
-					Signlink.dnslookup(TextClass.method586(anInt1193));
+                               if (anInt1193 != 0 && openInterfaceID == -1) {
+                                       Signlink.dnslookup(TextClass.intToIpString(anInt1193));
 					closeOpenInterfaces();
 					char c = '\u028A';
 					if (daysSinceRecovChange != 201 || membersInt == 1) {

--- a/2006Scape Client/src/main/java/RSInterface.java
+++ b/2006Scape Client/src/main/java/RSInterface.java
@@ -257,7 +257,7 @@ public final class RSInterface {
 	}
 
     private static Sprite loadSprite(int i, StreamLoader streamLoader, String s) {
-		long l = (TextClass.method585(s) << 8) + i;
+               long l = (TextClass.hashSpriteName(s) << 8) + i;
                 Sprite sprite = (Sprite) spriteCache.insertFromCache(l);
 		if (sprite != null) {
 			return sprite;

--- a/2006Scape Client/src/main/java/TextClass.java
+++ b/2006Scape Client/src/main/java/TextClass.java
@@ -46,7 +46,10 @@ final class TextClass {
 		throw new RuntimeException();
 	}
 
-	public static long method585(String s) {
+       /**
+        * Creates a stable hash for sprite names used in caching.
+        */
+       public static long hashSpriteName(String s) {
 		s = s.toUpperCase();
 		long l = 0L;
 		for (int i = 0; i < s.length(); i++) {
@@ -56,9 +59,12 @@ final class TextClass {
 		return l;
 	}
 
-	public static String method586(int i) {
-		return (i >> 24 & 0xff) + "." + (i >> 16 & 0xff) + "." + (i >> 8 & 0xff) + "." + (i & 0xff);
-	}
+       /**
+        * Converts an integer representation of an IP address to dotted notation.
+        */
+       public static String intToIpString(int i) {
+               return (i >> 24 & 0xff) + "." + (i >> 16 & 0xff) + "." + (i >> 8 & 0xff) + "." + (i & 0xff);
+       }
 
 	public static String fixName(String s) {
 		if (s.length() > 0) {


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes             | ❌ |
| ≥ 80 % coverage on touched lines    | ❌ |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

---

## 🔍 What & Why
Renamed two poorly named methods in `TextClass` to improve clarity and updated all call sites.

---

## 🗂️ Detailed Changes
- Added `hashSpriteName` for sprite name hashing
- Added `intToIpString` for IP conversion
- Updated usage in `RSInterface` and `Game`

---

## ♻️ Rename-Specific Fields

| Old Identifier | New Identifier |
| -------------- | -------------- |
| `method585` | `hashSpriteName` |
| `method586` | `intToIpString` |

- **Batch**: N/A
- **Revert command**: `git revert -m 1 7fd22fe8d6c273a95766d9f0cd69f2bfa14d74f3`

---

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java        |  4 ++--
 2006Scape Client/src/main/java/RSInterface.java |  2 +-
 2006Scape Client/src/main/java/TextClass.java   | 14 ++++++++++----
 3 files changed, 13 insertions(+), 7 deletions(-)
```

---

## 🧪 Integration-Test Log
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
2006Scape Client/src/main/java/Game.java:2767: warning: [removal] AppletContext in java.applet has been deprecated and marked for removal
        public AppletContext getAppletContext() {
               ^
2006Scape Client/src/main/java/Signlink.java:392: warning: [removal] Applet in java.applet has been deprecated and marked for removal
        public static Applet mainapp = null;
                      ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: 2006Scape Client/src/main/java/RSApplet.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
3 warnings
```

---

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of **AGENTS.md** applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_68651045b790832b97447f6a91411599