### PR TITLE
[BOT] refactor(rename): ShapedTile fields → descriptive names

### DIFF
--- a/2006Scape Client/src/main/java/ShapedTile.java
+++ b/2006Scape Client/src/main/java/ShapedTile.java
@@ -5,20 +5,20 @@
 final class ShapedTile {
 
         public ShapedTile(int i, int j, int k, int l, int i1, int j1, int k1, int l1, int i2, int j2, int k2, int l2, int i3, int j3, int k3, int l3, int i4, int k4, int l4) {
-		aBoolean683 = !(i3 != l2 || i3 != l || i3 != k2);
-		anInt684 = j3;
-		anInt685 = k1;
-		anInt686 = i2;
-		anInt687 = l4;
+		flatShading = !(i3 != l2 || i3 != l || i3 != k2);
+		shape = j3;
+		rotation = k1;
+		baseColor = i2;
+		shadeColor = l4;
 		char c = '\200';
 		int i5 = c / 2;
 		int j5 = c / 4;
 		int k5 = c * 3 / 4;
 		int ai[] = anIntArrayArray696[j3];
 		int l5 = ai.length;
-		anIntArray673 = new int[l5];
-		anIntArray674 = new int[l5];
-		anIntArray675 = new int[l5];
+		vertexX = new int[l5];
+		vertexZ = new int[l5];
+		vertexY = new int[l5];
 		int ai1[] = new int[l5];
 		int ai2[] = new int[l5];
 		int i6 = k4 * c;
@@ -136,23 +136,23 @@ final class ShapedTile {
 				k8 = k;
 				j9 = k3;
 			}
-			anIntArray673[k6] = i7;
-			anIntArray674[k6] = i8;
-			anIntArray675[k6] = k7;
+			vertexX[k6] = i7;
+			vertexZ[k6] = i8;
+			vertexY[k6] = k7;
 			ai1[k6] = k8;
 			ai2[k6] = j9;
 		}
 
 		int ai3[] = anIntArrayArray697[j3];
 		int j7 = ai3.length / 4;
-		anIntArray679 = new int[j7];
-		anIntArray680 = new int[j7];
-		anIntArray681 = new int[j7];
-		anIntArray676 = new int[j7];
-		anIntArray677 = new int[j7];
-		anIntArray678 = new int[j7];
+		faceVertexA = new int[j7];
+		faceVertexB = new int[j7];
+		faceVertexC = new int[j7];
+		faceColorA = new int[j7];
+		faceColorB = new int[j7];
+		faceColorC = new int[j7];
 		if (i1 != -1) {
-			anIntArray682 = new int[j7];
+			faceTexture = new int[j7];
 		}
 		int l7 = 0;
 		for (int j8 = 0; j8 < j7; j8++) {
@@ -170,22 +170,22 @@ final class ShapedTile {
 			if (k10 < 4) {
 				k10 = k10 - k1 & 3;
 			}
-			anIntArray679[j8] = k9;
-			anIntArray680[j8] = i10;
-			anIntArray681[j8] = k10;
+			faceVertexA[j8] = k9;
+			faceVertexB[j8] = i10;
+			faceVertexC[j8] = k10;
 			if (l8 == 0) {
-				anIntArray676[j8] = ai1[k9];
-				anIntArray677[j8] = ai1[i10];
-				anIntArray678[j8] = ai1[k10];
-				if (anIntArray682 != null) {
-					anIntArray682[j8] = -1;
+				faceColorA[j8] = ai1[k9];
+				faceColorB[j8] = ai1[i10];
+				faceColorC[j8] = ai1[k10];
+				if (faceTexture != null) {
+					faceTexture[j8] = -1;
 				}
 			} else {
-				anIntArray676[j8] = ai2[k9];
-				anIntArray677[j8] = ai2[i10];
-				anIntArray678[j8] = ai2[k10];
-				if (anIntArray682 != null) {
-					anIntArray682[j8] = i1;
+				faceColorA[j8] = ai2[k9];
+				faceColorB[j8] = ai2[i10];
+				faceColorC[j8] = ai2[k10];
+				if (faceTexture != null) {
+					faceTexture[j8] = i1;
 				}
 			}
 		}
@@ -214,26 +214,26 @@ final class ShapedTile {
 		l9 /= 14;
 	}
 
-	final int[] anIntArray673;
-	final int[] anIntArray674;
-	final int[] anIntArray675;
-	final int[] anIntArray676;
-	final int[] anIntArray677;
-	final int[] anIntArray678;
-	final int[] anIntArray679;
-	final int[] anIntArray680;
-	final int[] anIntArray681;
-	int anIntArray682[];
-	final boolean aBoolean683;
-	final int anInt684;
-	final int anInt685;
-	final int anInt686;
-	final int anInt687;
-	static final int[] anIntArray688 = new int[6];
-	static final int[] anIntArray689 = new int[6];
-	static final int[] anIntArray690 = new int[6];
-	static final int[] anIntArray691 = new int[6];
-	static final int[] anIntArray692 = new int[6];
+        final int[] vertexX;
+        final int[] vertexZ;
+        final int[] vertexY;
+        final int[] faceColorA;
+        final int[] faceColorB;
+        final int[] faceColorC;
+        final int[] faceVertexA;
+        final int[] faceVertexB;
+        final int[] faceVertexC;
+        int faceTexture[];
+        final boolean flatShading;
+        final int shape;
+        final int rotation;
+        final int baseColor;
+        final int shadeColor;
+        static final int[] projectedX = new int[6];
+        static final int[] projectedY = new int[6];
+        static final int[] cameraVertexX = new int[6];
+        static final int[] cameraVertexY = new int[6];
+        static final int[] cameraVertexZ = new int[6];
 	static final int[] anIntArray693 = {1, 0};
 	static final int[] anIntArray694 = {2, 1};
 	static final int[] anIntArray695 = {3, 3};

--- a/2006Scape Client/src/main/java/WorldController.java
+++ b/2006Scape Client/src/main/java/WorldController.java
@@ -752,10 +752,10 @@ final class WorldController {
                 if (shapedTile == null) {
                         return;
                 }
-                int l1 = shapedTile.anInt684;
-                int i2 = shapedTile.anInt685;
-                int j2 = shapedTile.anInt686;
-                int k2 = shapedTile.anInt687;
+                int l1 = shapedTile.shape;
+                int i2 = shapedTile.rotation;
+                int j2 = shapedTile.baseColor;
+                int k2 = shapedTile.shadeColor;
 		int ai1[] = anIntArrayArray489[l1];
 		int ai2[] = anIntArrayArray490[i2];
 		int l2 = 0;
@@ -1595,11 +1595,11 @@ final class WorldController {
 	}
 
         private void method316(int i, int j, int k, ShapedTile shapedTile, int l, int i1, int j1) {
-                int k1 = shapedTile.anIntArray673.length;
+                int k1 = shapedTile.vertexX.length;
                 for (int l1 = 0; l1 < k1; l1++) {
-                        int i2 = shapedTile.anIntArray673[l1] - anInt455;
-                        int k2 = shapedTile.anIntArray674[l1] - anInt456;
-                        int i3 = shapedTile.anIntArray675[l1] - anInt457;
+                        int i2 = shapedTile.vertexX[l1] - anInt455;
+                        int k2 = shapedTile.vertexZ[l1] - anInt456;
+                        int i3 = shapedTile.vertexY[l1] - anInt457;
 			int k3 = i3 * k + i2 * j1 >> 16;
 			i3 = i3 * j1 - i2 * k >> 16;
 			i2 = k3;
@@ -1609,46 +1609,46 @@ final class WorldController {
 			if (i3 < 50) {
 				return;
 			}
-                        if (shapedTile.anIntArray682 != null) {
-                                ShapedTile.anIntArray690[l1] = i2;
-                                ShapedTile.anIntArray691[l1] = k2;
-                                ShapedTile.anIntArray692[l1] = i3;
+                        if (shapedTile.faceTexture != null) {
+                                ShapedTile.cameraVertexX[l1] = i2;
+                                ShapedTile.cameraVertexY[l1] = k2;
+                                ShapedTile.cameraVertexZ[l1] = i3;
                         }
-                        ShapedTile.anIntArray688[l1] = Texture.textureInt1 + (i2 << 9) / i3;
-                        ShapedTile.anIntArray689[l1] = Texture.textureInt2 + (k2 << 9) / i3;
+                        ShapedTile.projectedX[l1] = Texture.textureInt1 + (i2 << 9) / i3;
+                        ShapedTile.projectedY[l1] = Texture.textureInt2 + (k2 << 9) / i3;
                 }
 
 		Texture.alpha = 0;
-                k1 = shapedTile.anIntArray679.length;
+                k1 = shapedTile.faceVertexA.length;
                 for (int j2 = 0; j2 < k1; j2++) {
-                        int l2 = shapedTile.anIntArray679[j2];
-                        int j3 = shapedTile.anIntArray680[j2];
-                        int l3 = shapedTile.anIntArray681[j2];
-                        int i4 = ShapedTile.anIntArray688[l2];
-                        int j4 = ShapedTile.anIntArray688[j3];
-                        int k4 = ShapedTile.anIntArray688[l3];
-                        int l4 = ShapedTile.anIntArray689[l2];
-                        int i5 = ShapedTile.anIntArray689[j3];
-                        int j5 = ShapedTile.anIntArray689[l3];
+                        int l2 = shapedTile.faceVertexA[j2];
+                        int j3 = shapedTile.faceVertexB[j2];
+                        int l3 = shapedTile.faceVertexC[j2];
+                        int i4 = ShapedTile.projectedX[l2];
+                        int j4 = ShapedTile.projectedX[j3];
+                        int k4 = ShapedTile.projectedX[l3];
+                        int l4 = ShapedTile.projectedY[l2];
+                        int i5 = ShapedTile.projectedY[j3];
+                        int j5 = ShapedTile.projectedY[l3];
 			if ((i4 - j4) * (j5 - i5) - (l4 - i5) * (k4 - j4) > 0) {
 				Texture.clip = i4 < 0 || j4 < 0 || k4 < 0 || i4 > DrawingArea.centerX || j4 > DrawingArea.centerX || k4 > DrawingArea.centerX;
 				if (aBoolean467 && method318(anInt468, anInt469, l4, i5, j5, i4, j4, k4)) {
 					anInt470 = i;
 					anInt471 = i1;
 				}
-                                if (shapedTile.anIntArray682 == null || shapedTile.anIntArray682[j2] == -1) {
-                                        if (shapedTile.anIntArray676[j2] != 0xbc614e) {
-                                                Texture.drawGouraudTriangle(l4, i5, j5, i4, j4, k4, shapedTile.anIntArray676[j2], shapedTile.anIntArray677[j2], shapedTile.anIntArray678[j2]);
+                                if (shapedTile.faceTexture == null || shapedTile.faceTexture[j2] == -1) {
+                                        if (shapedTile.faceColorA[j2] != 0xbc614e) {
+                                                Texture.drawGouraudTriangle(l4, i5, j5, i4, j4, k4, shapedTile.faceColorA[j2], shapedTile.faceColorB[j2], shapedTile.faceColorC[j2]);
                                         }
                                 } else if (!lowMem) {
-                                        if (shapedTile.aBoolean683) {
-                                                Texture.drawTexturedTriangle(l4, i5, j5, i4, j4, k4, shapedTile.anIntArray676[j2], shapedTile.anIntArray677[j2], shapedTile.anIntArray678[j2], ShapedTile.anIntArray690[0], ShapedTile.anIntArray690[1], ShapedTile.anIntArray690[3], ShapedTile.anIntArray691[0], ShapedTile.anIntArray691[1], ShapedTile.anIntArray691[3], ShapedTile.anIntArray692[0], ShapedTile.anIntArray692[1], ShapedTile.anIntArray692[3], shapedTile.anIntArray682[j2]);
+                                        if (shapedTile.flatShading) {
+                                                Texture.drawTexturedTriangle(l4, i5, j5, i4, j4, k4, shapedTile.faceColorA[j2], shapedTile.faceColorB[j2], shapedTile.faceColorC[j2], ShapedTile.cameraVertexX[0], ShapedTile.cameraVertexX[1], ShapedTile.cameraVertexX[3], ShapedTile.cameraVertexY[0], ShapedTile.cameraVertexY[1], ShapedTile.cameraVertexY[3], ShapedTile.cameraVertexZ[0], ShapedTile.cameraVertexZ[1], ShapedTile.cameraVertexZ[3], shapedTile.faceTexture[j2]);
                                         } else {
-                                                Texture.drawTexturedTriangle(l4, i5, j5, i4, j4, k4, shapedTile.anIntArray676[j2], shapedTile.anIntArray677[j2], shapedTile.anIntArray678[j2], ShapedTile.anIntArray690[l2], ShapedTile.anIntArray690[j3], ShapedTile.anIntArray690[l3], ShapedTile.anIntArray691[l2], ShapedTile.anIntArray691[j3], ShapedTile.anIntArray691[l3], ShapedTile.anIntArray692[l2], ShapedTile.anIntArray692[j3], ShapedTile.anIntArray692[l3], shapedTile.anIntArray682[j2]);
+                                                Texture.drawTexturedTriangle(l4, i5, j5, i4, j4, k4, shapedTile.faceColorA[j2], shapedTile.faceColorB[j2], shapedTile.faceColorC[j2], ShapedTile.cameraVertexX[l2], ShapedTile.cameraVertexX[j3], ShapedTile.cameraVertexX[l3], ShapedTile.cameraVertexY[l2], ShapedTile.cameraVertexY[j3], ShapedTile.cameraVertexY[l3], ShapedTile.cameraVertexZ[l2], ShapedTile.cameraVertexZ[j3], ShapedTile.cameraVertexZ[l3], shapedTile.faceTexture[j2]);
                                         }
                                 } else {
-                                        int k5 = anIntArray485[shapedTile.anIntArray682[j2]];
-                                        Texture.drawGouraudTriangle(l4, i5, j5, i4, j4, k4, method317(k5, shapedTile.anIntArray676[j2]), method317(k5, shapedTile.anIntArray677[j2]), method317(k5, shapedTile.anIntArray678[j2]));
+                                        int k5 = anIntArray485[shapedTile.faceTexture[j2]];
+                                        Texture.drawGouraudTriangle(l4, i5, j5, i4, j4, k4, method317(k5, shapedTile.faceColorA[j2]), method317(k5, shapedTile.faceColorB[j2]), method317(k5, shapedTile.faceColorC[j2]));
                                 }
                         }
                 }


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes             | ❌ |
| ≥ 80 % coverage on touched lines    | ❌ |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Refactor `ShapedTile` to replace obfuscated field names with descriptive ones. The change improves readability without altering behaviour.

## 🗂️ Detailed Changes
- Renamed fields inside `ShapedTile` to meaningful names
- Updated `WorldController` to reference the new identifiers

## ♻️ Rename‑Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| anIntArray673 | vertexX |
| anIntArray674 | vertexZ |
| anIntArray675 | vertexY |
| anIntArray676 | faceColorA |
| anIntArray677 | faceColorB |
| anIntArray678 | faceColorC |
| anIntArray679 | faceVertexA |
| anIntArray680 | faceVertexB |
| anIntArray681 | faceVertexC |
| anIntArray682 | faceTexture |
| aBoolean683 | flatShading |
| anInt684 | shape |
| anInt685 | rotation |
| anInt686 | baseColor |
| anInt687 | shadeColor |
| anIntArray688 | projectedX |
| anIntArray689 | projectedY |
| anIntArray690 | cameraVertexX |
| anIntArray691 | cameraVertexY |
| anIntArray692 | cameraVertexZ |

- **Batch**: N/A
- **Revert command**: `git revert -m 1 a2dba4a22ac141d7b59d15acd941937f42ff548e`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/ShapedTile.java     | 102 ++++++++++-----------
 .../src/main/java/WorldController.java             |  64 ++++++-------
 2 files changed, 83 insertions(+), 83 deletions(-)
```

## 🧪 Integration‑Test Log
Compilation via `javac` succeeded with warnings.

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of **AGENTS.md** applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_686520a42540832ba8febc10dc92968a