### PR TITLE
[BOT] refactor(rename): WorldController method and field names

### DIFF
--- a/2006Scape Client/src/main/java/ObjectManager.java
+++ b/2006Scape Client/src/main/java/ObjectManager.java
@@ -194,7 +194,7 @@ final class ObjectManager {
 									i22 = Texture.brightnessTable[method187(k21, 96)];
 								}
 								if (i19 == 0) {
-									worldController.method279(l, l6, k17, 0, 0, -1, j19, k19, l19, i20, method187(j21, j20), method187(j21, k20), method187(j21, l20), method187(j21, i21), 0, 0, 0, 0, i22, 0);
+                                                                        worldController.addTile(l, l6, k17, 0, 0, -1, j19, k19, l19, i20, method187(j21, j20), method187(j21, k20), method187(j21, l20), method187(j21, i21), 0, 0, 0, 0, i22, 0);
 								} else {
 									int k22 = aByteArrayArrayArray136[l][l6][k17] + 1;
 									byte byte4 = aByteArrayArrayArray148[l][l6][k17];
@@ -220,7 +220,7 @@ final class ObjectManager {
 										j23 = method177(flo_2.hue, flo_2.saturation, flo_2.lightness);
 										k23 = Texture.brightnessTable[method185(flo_2.blendColor, 96)];
 									}
-									worldController.method279(l, l6, k17, k22, byte4, i23, j19, k19, l19, i20, method187(j21, j20), method187(j21, k20), method187(j21, l20), method187(j21, i21), method185(j23, j20), method185(j23, k20), method185(j23, l20), method185(j23, i21), i22, k23);
+                                                                        worldController.addTile(l, l6, k17, k22, byte4, i23, j19, k19, l19, i20, method187(j21, j20), method187(j21, k20), method187(j21, l20), method187(j21, i21), method185(j23, j20), method185(j23, k20), method185(j23, l20), method185(j23, i21), i22, k23);
 								}
 							}
 						}
@@ -231,7 +231,7 @@ final class ObjectManager {
 
 			for (int j8 = 1; j8 < anInt147 - 1; j8++) {
 				for (int i10 = 1; i10 < anInt146 - 1; i10++) {
-					worldController.method278(l, i10, j8, method182(j8, l, i10));
+                                        worldController.setGroundFlag(l, i10, j8, method182(j8, l, i10));
 				}
 
 			}
@@ -294,7 +294,7 @@ final class ObjectManager {
 								char c1 = '\360';
 								int k14 = anIntArrayArrayArray129[k8][i4][k4] - c1;
 								int l15 = anIntArrayArrayArray129[i7][i4][k4];
-								WorldController.method277(l2, i4 * 128, l15, i4 * 128, l5 * 128 + 128, k14, k4 * 128, 1);
+                                                            WorldController.addCullingCluster(l2, i4 * 128, l15, i4 * 128, l5 * 128 + 128, k14, k4 * 128, 1);
 								for (int l16 = i7; l16 <= k8; l16++) {
 									for (int l17 = k4; l17 <= l5; l17++) {
 										anIntArrayArrayArray135[l16][i4][l17] &= ~i2;
@@ -338,7 +338,7 @@ final class ObjectManager {
 								char c2 = '\360';
 								int l14 = anIntArrayArrayArray129[l8][l4][k3] - c2;
 								int i16 = anIntArrayArrayArray129[j7][l4][k3];
-								WorldController.method277(l2, l4 * 128, i16, i6 * 128 + 128, k3 * 128, l14, k3 * 128, 2);
+                                                            WorldController.addCullingCluster(l2, l4 * 128, i16, i6 * 128 + 128, k3 * 128, l14, k3 * 128, 2);
 								for (int i17 = j7; i17 <= l8; i17++) {
 									for (int i18 = l4; i18 <= i6; i18++) {
 										anIntArrayArrayArray135[i17][i18][k3] &= ~j2;
@@ -379,7 +379,7 @@ final class ObjectManager {
 
 							if ((j6 - i5 + 1) * (i9 - k7 + 1) >= 4) {
 								int j12 = anIntArrayArrayArray129[i3][i5][k7];
-								WorldController.method277(l2, i5 * 128, j12, j6 * 128 + 128, i9 * 128 + 128, j12, k7 * 128, 4);
+                                                            WorldController.addCullingCluster(l2, i5 * 128, j12, j6 * 128 + 128, i9 * 128 + 128, j12, k7 * 128, 4);
 								for (int k13 = i5; k13 <= j6; k13++) {
 									for (int i15 = k7; i15 <= i9; i15++) {
 										anIntArrayArrayArray135[i3][k13][i15] &= ~k2;

--- a/2006Scape Client/src/main/java/WorldController.java
+++ b/2006Scape Client/src/main/java/WorldController.java
@@ -10,7 +10,7 @@ final class WorldController {
 		int j = 104;// was parameter
 		int k = 4;// was parameter
 		aBoolean434 = true;
-        obj5Cache = new SceneObject[5000];
+        sceneObjectCache = new SceneObject[5000];
 		anIntArray486 = new int[10000];
 		anIntArray487 = new int[10000];
                 planeCount = k;
@@ -49,11 +49,11 @@ final class WorldController {
 			anIntArray473[l] = 0;
 		}
 
-		for (int k1 = 0; k1 < obj5CacheCurrPos; k1++) {
-			obj5Cache[k1] = null;
-		}
+                for (int k1 = 0; k1 < sceneObjectCachePos; k1++) {
+                        sceneObjectCache[k1] = null;
+                }
 
-		obj5CacheCurrPos = 0;
+                sceneObjectCachePos = 0;
 		for (int l1 = 0; l1 < aClass28Array462.length; l1++) {
 			aClass28Array462[l1] = null;
 		}
@@ -95,7 +95,7 @@ final class WorldController {
 		groundArray[3][j][i] = null;
 	}
 
-        public static void method277(int i, int j, int k, int l, int i1, int j1, int l1, int i2) {
+        public static void addCullingCluster(int i, int j, int k, int l, int i1, int j1, int l1, int i2) {
                 CullingCluster cluster = new CullingCluster();
                 cluster.minTileX = j / 128;
                 cluster.maxTileX = l / 128;
@@ -111,14 +111,14 @@ final class WorldController {
                 aCullingClusters[i][anIntArray473[i]++] = cluster;
         }
 
-	public void method278(int i, int j, int k, int l) {
+        public void setGroundFlag(int i, int j, int k, int l) {
 		Ground class30_sub3 = groundArray[i][j][k];
 		if (class30_sub3 != null) {
 			groundArray[i][j][k].anInt1321 = l;
 		}
 	}
 
-	public void method279(int i, int j, int k, int l, int i1, int j1, int k1, int l1, int i2, int j2, int k2, int l2, int i3, int j3, int k3, int l3, int i4, int j4, int k4, int l4) {
+        public void addTile(int i, int j, int k, int l, int i1, int j1, int k1, int l1, int i2, int j2, int k2, int l2, int i3, int j3, int k3, int l3, int i4, int j4, int k4, int l4) {
 		if (l == 0) {
                     PlainTile class43 = new PlainTile(k2, l2, i3, j3, -1, k4, false);
 			for (int i5 = i; i5 >= 0; i5--) {
@@ -343,19 +343,19 @@ final class WorldController {
 		}
 
                 if (flag) {
-                        obj5Cache[obj5CacheCurrPos++] = sceneObject;
+                        sceneObjectCache[sceneObjectCachePos++] = sceneObject;
                 }
 		return true;
 	}
 
         public void clearObj5Cache() {
-                for (int i = 0; i < obj5CacheCurrPos; i++) {
-                        SceneObject object = obj5Cache[i];
+                for (int i = 0; i < sceneObjectCachePos; i++) {
+                        SceneObject object = sceneObjectCache[i];
                         method289(object);
-                        obj5Cache[i] = null;
+                        sceneObjectCache[i] = null;
                 }
 
-		obj5CacheCurrPos = 0;
+            sceneObjectCachePos = 0;
 	}
 
         private void method289(SceneObject sceneObject) {
@@ -2056,8 +2056,8 @@ final class WorldController {
 	private final int[][][] anIntArrayArrayArray440;
 	private final Ground[][][] groundArray;
 	private int activePlane;
-        private int obj5CacheCurrPos;
-        private final SceneObject[] obj5Cache;
+        private int sceneObjectCachePos;
+        private final SceneObject[] sceneObjectCache;
 	private final int[][][] anIntArrayArrayArray445;
 	private static int anInt446;
 	private static int anInt447;


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

---

## 🔍 What & Why
Refactor `WorldController` by providing descriptive method and field names. This improves readability with no logic changes.

---

## 🗂️ Detailed Changes
- renamed methods in `WorldController` and updated usages in `ObjectManager`
- renamed scene object cache fields

---

## ♻️ Rename-Specific Fields

| Old Identifier    | New Identifier       |
| ----------------- | -------------------- |
| `method277`       | `addCullingCluster`  |
| `method278`       | `setGroundFlag`      |
| `method279`       | `addTile`            |
| `obj5Cache`       | `sceneObjectCache`   |
| `obj5CacheCurrPos`| `sceneObjectCachePos`|

- **Batch**: N/A
- **Revert command**: `git revert -m 1 ebe7eb58`

---

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/ObjectManager.java  | 12 ++++-----
 2006Scape Client/src/main/java/WorldController.java | 30 +++++++++++-----------
 2 files changed, 21 insertions(+), 21 deletions(-)
```

---

## 🧪 Integration-Test Log
Compilation via `javac` succeeded with warnings:
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
...
3 warnings
```

---

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of AGENTS.md applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_686543800070832b94e58c17ed8f6a93