### PR TITLE
[BOT] refactor(rename): anInt1707 → animationStartCycle

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -2311,10 +2311,10 @@ public class Game extends RSApplet {
 			if (j1 < 0 || j1 >= 104 || k1 < 0 || k1 >= 104) {
 				continue;
 			}
-			if (player.aModel_1714 != null && loopCycle >= player.anInt1707 && loopCycle < player.anInt1708) {
+                        if (player.aModel_1714 != null && loopCycle >= player.animationStartCycle && loopCycle < player.animationEndCycle) {
 				player.aBoolean1699 = false;
-				player.anInt1709 = method42(plane, player.y, player.x);
-                               worldController.addAnimatingObject(plane, player.y, player, player.currentHeading, player.anInt1722, player.x, player.anInt1709, player.anInt1719, player.anInt1721, i1, player.anInt1720);
+                                player.animationBaseY = method42(plane, player.y, player.x);
+                               worldController.addAnimatingObject(plane, player.y, player, player.currentHeading, player.anInt1722, player.x, player.animationBaseY, player.anInt1719, player.anInt1721, i1, player.anInt1720);
 				continue;
 			}
 			if ((player.x & 0x7f) == 64 && (player.y & 0x7f) == 64) {
@@ -2323,8 +2323,8 @@ public class Game extends RSApplet {
 				}
 				anIntArrayArray929[j1][k1] = anInt1265;
 			}
-			player.anInt1709 = method42(plane, player.y, player.x);
-                      worldController.addAnimableObject(plane, player.currentHeading, player.anInt1709, i1, player.y, 60, player.x, player, player.aBoolean1541);
+                        player.animationBaseY = method42(plane, player.y, player.x);
+                      worldController.addAnimableObject(plane, player.currentHeading, player.animationBaseY, i1, player.y, 60, player.x, player, player.aBoolean1541);
 		}
 
 	}
@@ -10169,8 +10169,8 @@ public class Game extends RSApplet {
 				Model model = class46.getModel(j19, i20, i22, j22, k22, l22, -1);
 				if (model != null) {
 					method130(k17 + 1, -1, 0, l20, j7, 0, plane, k4, l14 + 1);
-					player.anInt1707 = l14 + loopCycle;
-					player.anInt1708 = k17 + loopCycle;
+                                player.animationStartCycle = l14 + loopCycle;
+                                player.animationEndCycle = k17 + loopCycle;
 					player.aModel_1714 = model;
 					int i23 = class46.sizeX;
 					int j23 = class46.sizeY;
@@ -10178,9 +10178,9 @@ public class Game extends RSApplet {
 						i23 = class46.sizeY;
 						j23 = class46.sizeX;
 					}
-					player.anInt1711 = k4 * 128 + i23 * 64;
-					player.anInt1713 = j7 * 128 + j23 * 64;
-					player.anInt1712 = method42(plane, player.anInt1713, player.anInt1711);
+                                player.animationBaseX = k4 * 128 + i23 * 64;
+                                player.animationBaseZ = j7 * 128 + j23 * 64;
+                                player.animationBaseHeight = method42(plane, player.animationBaseZ, player.animationBaseX);
 					if (byte2 > byte0) {
 						byte byte4 = byte2;
 						byte2 = byte0;

--- a/2006Scape Client/src/main/java/Player.java
+++ b/2006Scape Client/src/main/java/Player.java
@@ -37,12 +37,12 @@ public final class Player extends Entity {
 			}
 		}
 		if (aModel_1714 != null) {
-			if (Game.loopCycle >= anInt1708) {
+			if (Game.loopCycle >= animationEndCycle) {
 				aModel_1714 = null;
 			}
-			if (Game.loopCycle >= anInt1707 && Game.loopCycle < anInt1708) {
+			if (Game.loopCycle >= animationStartCycle && Game.loopCycle < animationEndCycle) {
 				Model model_1 = aModel_1714;
-				model_1.translate(anInt1711 - super.x, anInt1712 - anInt1709, anInt1713 - super.y);
+				model_1.translate(animationBaseX - super.x, animationBaseHeight - animationBaseY, animationBaseZ - super.y);
 				if (super.turnDirection == 512) {
 					model_1.calculateNormals();
 					model_1.calculateNormals();
@@ -65,7 +65,7 @@ public final class Player extends Entity {
 					model_1.calculateNormals();
 					model_1.calculateNormals();
 				}
-				model_1.translate(super.x - anInt1711, anInt1709 - anInt1712, super.y - anInt1713);
+				model_1.translate(super.x - animationBaseX, animationBaseY - animationBaseHeight, super.y - animationBaseZ);
 			}
 		}
 		model.aBoolean1659 = true;
@@ -139,27 +139,27 @@ public final class Player extends Entity {
 		combatLevel = stream.readUnsignedByte();
 		skill = stream.readUnsignedWord();
 		visible = true;
-		aLong1718 = 0L;
+		appearanceHash = 0L;
 		for (int k1 = 0; k1 < 12; k1++) {
-			aLong1718 <<= 4;
+			appearanceHash <<= 4;
 			if (equipment[k1] >= 256) {
-				aLong1718 += equipment[k1] - 256;
+				appearanceHash += equipment[k1] - 256;
 			}
 		}
 
 		if (equipment[0] >= 256) {
-			aLong1718 += equipment[0] - 256 >> 4;
+			appearanceHash += equipment[0] - 256 >> 4;
 		}
 		if (equipment[1] >= 256) {
-			aLong1718 += equipment[1] - 256 >> 8;
+			appearanceHash += equipment[1] - 256 >> 8;
 		}
 		for (int i2 = 0; i2 < 5; i2++) {
-			aLong1718 <<= 3;
-                        aLong1718 += bodyColors[i2];
+			appearanceHash <<= 3;
+                        appearanceHash += bodyColors[i2];
 		}
 
-                aLong1718 <<= 1;
-                aLong1718 += gender;
+                appearanceHash <<= 1;
+                appearanceHash += gender;
 	}
 
         private Model getBaseModel() {
@@ -173,7 +173,7 @@ public final class Player extends Entity {
 			Model model = desc.method164(-1, j, null);
 			return model;
 		}
-		long l = aLong1718;
+		long l = appearanceHash;
 		int k = -1;
 		int i1 = -1;
 		int j1 = -1;
@@ -215,8 +215,8 @@ public final class Player extends Entity {
 			}
 
 			if (flag) {
-				if (aLong1697 != -1L) {
-					model_1 = (Model) mruNodes.insertFromCache(aLong1697);
+				if (cachedModelHash != -1L) {
+					model_1 = (Model) mruNodes.insertFromCache(cachedModelHash);
 				}
 				if (model_1 == null) {
 					return null;
@@ -261,7 +261,7 @@ public final class Player extends Entity {
 			model_1.buildVertexGroups();
 			model_1.applyLighting(64, 850, -30, -50, -30, true);
 			mruNodes.removeFromCache(model_1, l);
-			aLong1697 = l;
+			cachedModelHash = l;
 		}
 		if (aBoolean1699) {
 			return model_1;
@@ -338,14 +338,14 @@ public final class Player extends Entity {
 	}
 
 	Player() {
-		aLong1697 = -1L;
+		cachedModelHash = -1L;
 		aBoolean1699 = false;
                 bodyColors = new int[5];
 		visible = false;
 		equipment = new int[12];
 	}
 
-	private long aLong1697;
+        private long cachedModelHash;
 	public EntityDef desc;
 	boolean aBoolean1699;
         final int[] bodyColors;
@@ -357,16 +357,16 @@ public final class Player extends Entity {
 	public int headIcon;
 	public int skullIcon;
 	public int hintIcon;
-	public int anInt1707;
-	int anInt1708;
-	int anInt1709;
+        public int animationStartCycle;
+        int animationEndCycle;
+        int animationBaseY;
 	boolean visible;
-	int anInt1711;
-	int anInt1712;
-	int anInt1713;
+        int animationBaseX;
+        int animationBaseHeight;
+        int animationBaseZ;
 	Model aModel_1714;
 	public final int[] equipment;
-	private long aLong1718;
+        private long appearanceHash;
 	int anInt1719;
 	int anInt1720;
 	int anInt1721;


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item | Status |
| --- | --- |
| `mvn -B verify -o` passes (offline) | ❌ *(unavailable)* |
| `spotbugs:check` passes | ❌ *(unavailable)* |
| ≥ 80 % coverage on touched lines | ❌ *(unavailable)* |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why
Renamed several poorly named fields in `Player` to descriptive identifiers for clarity.

## 🗂️ Detailed Changes
- Updated `Player` field names and all usages
- Adjusted references in `Game`

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| `anInt1707` | `animationStartCycle` |
| `anInt1708` | `animationEndCycle` |
| `anInt1709` | `animationBaseY` |
| `anInt1711` | `animationBaseX` |
| `anInt1712` | `animationBaseHeight` |
| `anInt1713` | `animationBaseZ` |
| `aLong1697` | `cachedModelHash` |
| `aLong1718` | `appearanceHash` |

- **Batch**: 1
- **Revert command**: `git revert -m 1 a98cc5c66afbe77e518697070b1fb2e8fa211a3d`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java   | 20 ++++++------
 2006Scape Client/src/main/java/Player.java | 52 +++++++++++++++---------------
 2 files changed, 36 insertions(+), 36 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeds with warnings:
```
$ git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac
...(warnings)...
```

## 📝 Rollback Plan
Use the revert command above if any issues arise after merging.

------
https://chatgpt.com/codex/tasks/task_e_68655636f9dc832b979033a21c5d92d4