### PR TITLE
[BOT] refactor(rename): IDK → better identifiers

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -2221,9 +2221,9 @@ public class Game extends RSApplet {
 		for (int j = 0; j < 7; j++) {
 			anIntArray1065[j] = -1;
 			for (int k = 0; k < IDK.length; k++) {
-				if (IDK.cache[k].aBoolean662 || IDK.cache[k].anInt657 != j + (aBoolean1047 ? 0 : 7)) {
-					continue;
-				}
+                                if (IDK.cache[k].nonSelectable || IDK.cache[k].bodyPartId != j + (aBoolean1047 ? 0 : 7)) {
+                                        continue;
+                                }
 				anIntArray1065[j] = k;
 				break;
 			}
@@ -2381,7 +2381,7 @@ public class Game extends RSApplet {
 					if (j1 == 1 && ++i2 >= IDK.length) {
 						i2 = 0;
 					}
-				} while (IDK.cache[i2].aBoolean662 || IDK.cache[i2].anInt657 != k + (aBoolean1047 ? 0 : 7));
+                                } while (IDK.cache[i2].nonSelectable || IDK.cache[i2].bodyPartId != k + (aBoolean1047 ? 0 : 7));
 				anIntArray1065[k] = i2;
 				aBoolean1031 = true;
 			}
@@ -5395,7 +5395,7 @@ public class Game extends RSApplet {
 			if (aBoolean1031) {
 				for (int k1 = 0; k1 < 7; k1++) {
 					int l1 = anIntArray1065[k1];
-					if (l1 >= 0 && !IDK.cache[l1].method537()) {
+                                        if (l1 >= 0 && !IDK.cache[l1].ready()) {
 						return;
 					}
 				}
@@ -5406,7 +5406,7 @@ public class Game extends RSApplet {
 				for (int j2 = 0; j2 < 7; j2++) {
 					int k2 = anIntArray1065[j2];
 					if (k2 >= 0) {
-						aclass30_sub2_sub4_sub6s[i2++] = IDK.cache[k2].method538();
+                                                aclass30_sub2_sub4_sub6s[i2++] = IDK.cache[k2].getBodyModel();
 					}
 				}
 

--- a/2006Scape Client/src/main/java/IDK.java
+++ b/2006Scape Client/src/main/java/IDK.java
@@ -25,111 +25,111 @@ public final class IDK {
 				return;
 			}
 			if (i == 1) {
-				anInt657 = stream.readUnsignedByte();
+                                bodyPartId = stream.readUnsignedByte();
 			} else if (i == 2) {
 				int j = stream.readUnsignedByte();
-				anIntArray658 = new int[j];
+                                modelIds = new int[j];
 				for (int k = 0; k < j; k++) {
-					anIntArray658[k] = stream.readUnsignedWord();
+                                        modelIds[k] = stream.readUnsignedWord();
 				}
 
 			} else if (i == 3) {
-				aBoolean662 = true;
+                                nonSelectable = true;
 			} else if (i >= 40 && i < 50) {
-				anIntArray659[i - 40] = stream.readUnsignedWord();
+                                recolorOriginal[i - 40] = stream.readUnsignedWord();
 			} else if (i >= 50 && i < 60) {
-				anIntArray660[i - 50] = stream.readUnsignedWord();
+                                recolorTarget[i - 50] = stream.readUnsignedWord();
 			} else if (i >= 60 && i < 70) {
-				anIntArray661[i - 60] = stream.readUnsignedWord();
+                                headModelIds[i - 60] = stream.readUnsignedWord();
 			} else {
 				System.out.println("Error unrecognised config code: " + i);
 			}
 		} while (true);
 	}
 
-	public boolean method537() {
-		if (anIntArray658 == null) {
-			return true;
-		}
-		boolean flag = true;
-		for (int j = 0; j < anIntArray658.length; j++) {
-			if (!Model.isLoaded(anIntArray658[j])) {
-				flag = false;
-			}
-		}
+        public boolean ready() {
+                if (modelIds == null) {
+                        return true;
+                }
+                boolean flag = true;
+                for (int j = 0; j < modelIds.length; j++) {
+                        if (!Model.isLoaded(modelIds[j])) {
+                                flag = false;
+                        }
+                }
 
-		return flag;
-	}
+                return flag;
+        }
 
-	public Model method538() {
-		if (anIntArray658 == null) {
-			return null;
-		}
-		Model aclass30_sub2_sub4_sub6s[] = new Model[anIntArray658.length];
-		for (int i = 0; i < anIntArray658.length; i++) {
-			aclass30_sub2_sub4_sub6s[i] = Model.create(anIntArray658[i]);
-		}
+        public Model getBodyModel() {
+                if (modelIds == null) {
+                        return null;
+                }
+                Model aclass30_sub2_sub4_sub6s[] = new Model[modelIds.length];
+                for (int i = 0; i < modelIds.length; i++) {
+                        aclass30_sub2_sub4_sub6s[i] = Model.create(modelIds[i]);
+                }
 
 		Model model;
-		if (aclass30_sub2_sub4_sub6s.length == 1) {
-			model = aclass30_sub2_sub4_sub6s[0];
-		} else {
-			model = new Model(aclass30_sub2_sub4_sub6s.length, aclass30_sub2_sub4_sub6s);
-		}
-		for (int j = 0; j < 6; j++) {
-			if (anIntArray659[j] == 0) {
-				break;
-			}
-			model.recolor(anIntArray659[j], anIntArray660[j]);
-		}
+                if (aclass30_sub2_sub4_sub6s.length == 1) {
+                        model = aclass30_sub2_sub4_sub6s[0];
+                } else {
+                        model = new Model(aclass30_sub2_sub4_sub6s.length, aclass30_sub2_sub4_sub6s);
+                }
+                for (int j = 0; j < 6; j++) {
+                        if (recolorOriginal[j] == 0) {
+                                break;
+                        }
+                        model.recolor(recolorOriginal[j], recolorTarget[j]);
+                }
 
-		return model;
-	}
+                return model;
+        }
 
-	public boolean method539() {
-		boolean flag1 = true;
-		for (int i = 0; i < 5; i++) {
-			if (anIntArray661[i] != -1 && !Model.isLoaded(anIntArray661[i])) {
-				flag1 = false;
-			}
-		}
+        public boolean headLoaded() {
+                boolean flag1 = true;
+                for (int i = 0; i < 5; i++) {
+                        if (headModelIds[i] != -1 && !Model.isLoaded(headModelIds[i])) {
+                                flag1 = false;
+                        }
+                }
 
 		return flag1;
 	}
 
-	public Model method540() {
-		Model aclass30_sub2_sub4_sub6s[] = new Model[5];
-		int j = 0;
-		for (int k = 0; k < 5; k++) {
-			if (anIntArray661[k] != -1) {
-				aclass30_sub2_sub4_sub6s[j++] = Model.create(anIntArray661[k]);
-			}
-		}
+        public Model getHeadModel() {
+                Model aclass30_sub2_sub4_sub6s[] = new Model[5];
+                int j = 0;
+                for (int k = 0; k < 5; k++) {
+                        if (headModelIds[k] != -1) {
+                                aclass30_sub2_sub4_sub6s[j++] = Model.create(headModelIds[k]);
+                        }
+                }
 
-		Model model = new Model(j, aclass30_sub2_sub4_sub6s);
-		for (int l = 0; l < 6; l++) {
-			if (anIntArray659[l] == 0) {
-				break;
-			}
-			model.recolor(anIntArray659[l], anIntArray660[l]);
-		}
+                Model model = new Model(j, aclass30_sub2_sub4_sub6s);
+                for (int l = 0; l < 6; l++) {
+                        if (recolorOriginal[l] == 0) {
+                                break;
+                        }
+                        model.recolor(recolorOriginal[l], recolorTarget[l]);
+                }
 
-		return model;
-	}
+                return model;
+        }
 
-	private IDK() {
-		anInt657 = -1;
-		anIntArray659 = new int[6];
-		anIntArray660 = new int[6];
-		aBoolean662 = false;
-	}
+        private IDK() {
+                bodyPartId = -1;
+                recolorOriginal = new int[6];
+                recolorTarget = new int[6];
+                nonSelectable = false;
+        }
 
 	public static int length;
 	public static IDK cache[];
-	public int anInt657;
-	private int[] anIntArray658;
-	private final int[] anIntArray659;
-	private final int[] anIntArray660;
-	private final int[] anIntArray661 = {-1, -1, -1, -1, -1};
-	public boolean aBoolean662;
+        public int bodyPartId;
+        private int[] modelIds;
+        private final int[] recolorOriginal;
+        private final int[] recolorTarget;
+        private final int[] headModelIds = {-1, -1, -1, -1, -1};
+        public boolean nonSelectable;
 }

--- a/2006Scape Client/src/main/java/Player.java
+++ b/2006Scape Client/src/main/java/Player.java
@@ -206,7 +206,7 @@ public final class Player extends Entity {
 				if (j1 >= 0 && i2 == 5) {
 					k2 = j1;
 				}
-				if (k2 >= 256 && k2 < 512 && !IDK.cache[k2 - 256].method537()) {
+                                if (k2 >= 256 && k2 < 512 && !IDK.cache[k2 - 256].ready()) {
 					flag = true;
 				}
                                if (k2 >= 512 && !ItemDef.lookup(k2 - 512).areWearModelsCached(gender)) {
@@ -235,7 +235,7 @@ public final class Player extends Entity {
 					i3 = j1;
 				}
 				if (i3 >= 256 && i3 < 512) {
-					Model model_3 = IDK.cache[i3 - 256].method538();
+                                        Model model_3 = IDK.cache[i3 - 256].getBodyModel();
 					if (model_3 != null) {
 						aclass30_sub2_sub4_sub6s[j2++] = model_3;
 					}
@@ -295,7 +295,7 @@ public final class Player extends Entity {
 		boolean flag = false;
 		for (int i = 0; i < 12; i++) {
 			int j = equipment[i];
-			if (j >= 256 && j < 512 && !IDK.cache[j - 256].method539()) {
+                        if (j >= 256 && j < 512 && !IDK.cache[j - 256].headLoaded()) {
 				flag = true;
 			}
                        if (j >= 512 && !ItemDef.lookup(j - 512).areDialogueModelsCached(gender)) {
@@ -311,7 +311,7 @@ public final class Player extends Entity {
 		for (int l = 0; l < 12; l++) {
 			int i1 = equipment[l];
 			if (i1 >= 256 && i1 < 512) {
-				Model model_1 = IDK.cache[i1 - 256].method540();
+                                Model model_1 = IDK.cache[i1 - 256].getHeadModel();
 				if (model_1 != null) {
 					aclass30_sub2_sub4_sub6s[k++] = model_1;
 				}


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

> **PR Title format**: `[BOT] <type(scope)>: <summary>`
> Example: `[BOT] refactor(rename): Class29 → SoundEnvelope`

---

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

---

## 🔍 What & Why
Refactored `IDK` to improve readability of its API. The old obfuscated names were unclear, so methods and fields were renamed for clarity. All usages were updated accordingly in `Player` and `Game`.

---

## 🗂️ Detailed Changes
- Renamed `IDK` methods and fields
- Updated references in `Game.java` and `Player.java`
- Verified compilation via `javac`

---

## ♻️ Rename-Specific Fields

| Old Identifier | New Identifier |
| -------------- | -------------- |
| `method537()` | `ready()` |
| `method538()` | `getBodyModel()` |
| `method539()` | `headLoaded()` |
| `method540()` | `getHeadModel()` |
| `anInt657` | `bodyPartId` |
| `anIntArray658` | `modelIds` |
| `anIntArray659` | `recolorOriginal` |
| `anIntArray660` | `recolorTarget` |
| `anIntArray661` | `headModelIds` |
| `aBoolean662` | `nonSelectable` |

- **Batch**: 
- **Revert command**: `git revert -m 1 6317832f`

---

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Game.java   |  12 +--
 2006Scape Client/src/main/java/IDK.java    | 166 ++++++++++++++---------------
 2006Scape Client/src/main/java/Player.java |   8 +-
 3 files changed, 93 insertions(+), 93 deletions(-)
```

---

## 🧪 Integration-Test Log
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
public class RSApplet extends Applet implements Runnable, MouseListener, MouseWheelListener, MouseMotionListener, KeyListener, FocusListener, WindowListener {
                              ^
2006Scape Client/src/main/java/Game.java:2767: warning: [removal] AppletContext in java.applet has been deprecated and marked for removal
        public AppletContext getAppletContext() {
               ^
2006Scape Client/src/main/java/Signlink.java:392: warning: [removal] Applet in java.applet has been deprecated and marked for removal
        public static Applet mainapp = null;
                      ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: 2006Scape Client/src/main/java/RSApplet.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
3 warnings
```

---

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of **AGENTS.md** applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_686570f87d9c832bb40c985123101645