### PR TITLE
[BOT] refactor(rename): method258 → getFrameDelay

### DIFF
--- a/2006Scape Client/src/main/java/Animation.java
+++ b/2006Scape Client/src/main/java/Animation.java
@@ -18,19 +18,19 @@ public final class Animation {
 		}
 	}
 
-	public int method258(int i) {
-                int j = anIntArray355[i];
-                if (j == 0) {
-                        AnimFrame frame = AnimFrame.forId(anIntArray353[i]);
-                        if (frame != null) {
-                                j = anIntArray355[i] = frame.delay;
-                        }
-		}
-		if (j == 0) {
-			j = 1;
-		}
-		return j;
-	}
+       public int getFrameDelay(int frameIndex) {
+               int j = anIntArray355[frameIndex];
+               if (j == 0) {
+                       AnimFrame frame = AnimFrame.forId(anIntArray353[frameIndex]);
+                       if (frame != null) {
+                               j = anIntArray355[frameIndex] = frame.delay;
+                       }
+               }
+               if (j == 0) {
+                       j = 1;
+               }
+               return j;
+       }
 
 	private void readValues(Stream stream) {
 		do {

--- a/2006Scape Client/src/main/java/DynamicObject.java
+++ b/2006Scape Client/src/main/java/DynamicObject.java
@@ -12,8 +12,8 @@ final class DynamicObject extends Animable {
 			if (k > 100 && animation.anInt356 > 0) {
 				k = 100;
 			}
-			while (k > animation.method258(currentFrame)) {
-				k -= animation.method258(currentFrame);
+                       while (k > animation.getFrameDelay(currentFrame)) {
+                               k -= animation.getFrameDelay(currentFrame);
 				currentFrame++;
 				if (currentFrame < animation.anInt352) {
 					continue;
@@ -76,7 +76,7 @@ final class DynamicObject extends Animable {
 			cycleStart = Game.loopCycle;
 			if (flag && animation.anInt356 != -1) {
 				currentFrame = (int) (Math.random() * animation.anInt352);
-				cycleStart -= (int) (Math.random() * animation.method258(currentFrame));
+                                cycleStart -= (int) (Math.random() * animation.getFrameDelay(currentFrame));
 			}
 		}
 		ObjectDef class46 = ObjectDef.forID(id);

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -7605,7 +7605,7 @@ public class Game extends RSApplet {
 	}
 
         public void updateInterpolatedMovement(Entity entity) {
-		if (entity.anInt1548 == loopCycle || entity.anim == -1 || entity.anInt1529 != 0 || entity.anInt1528 + 1 > Animation.anims[entity.anim].method258(entity.anInt1527)) {
+        if (entity.anInt1548 == loopCycle || entity.anim == -1 || entity.anInt1529 != 0 || entity.anInt1528 + 1 > Animation.anims[entity.anim].getFrameDelay(entity.anInt1527)) {
 			int i = entity.anInt1548 - entity.anInt1547;
 			int j = loopCycle - entity.anInt1547;
 			int k = entity.anInt1543 * 128 + entity.anInt1540 * 64;
@@ -7806,7 +7806,7 @@ public class Game extends RSApplet {
 		if (entity.anInt1517 != -1) {
 			Animation animation = Animation.anims[entity.anInt1517];
 			entity.anInt1519++;
-			if (entity.anInt1518 < animation.anInt352 && entity.anInt1519 > animation.method258(entity.anInt1518)) {
+                        if (entity.anInt1518 < animation.anInt352 && entity.anInt1519 > animation.getFrameDelay(entity.anInt1518)) {
 				entity.anInt1519 = 0;
 				entity.anInt1518++;
 			}
@@ -7820,8 +7820,8 @@ public class Game extends RSApplet {
                                entity.spotAnimFrame = 0;
                        }
                        Animation animation_1 = SpotAnim.cache[entity.spotAnimId].aAnimation_407;
-                       for (entity.spotAnimFrameCycle++; entity.spotAnimFrame < animation_1.anInt352 && entity.spotAnimFrameCycle > animation_1.method258(entity.spotAnimFrame); entity.spotAnimFrame++) {
-                               entity.spotAnimFrameCycle -= animation_1.method258(entity.spotAnimFrame);
+                       for (entity.spotAnimFrameCycle++; entity.spotAnimFrame < animation_1.anInt352 && entity.spotAnimFrameCycle > animation_1.getFrameDelay(entity.spotAnimFrame); entity.spotAnimFrame++) {
+                               entity.spotAnimFrameCycle -= animation_1.getFrameDelay(entity.spotAnimFrame);
                        }
 
                        if (entity.spotAnimFrame >= animation_1.anInt352 && (entity.spotAnimFrame < 0 || entity.spotAnimFrame >= animation_1.anInt352)) {
@@ -7837,8 +7837,8 @@ public class Game extends RSApplet {
 		}
 		if (entity.anim != -1 && entity.anInt1529 == 0) {
 			Animation animation_3 = Animation.anims[entity.anim];
-			for (entity.anInt1528++; entity.anInt1527 < animation_3.anInt352 && entity.anInt1528 > animation_3.method258(entity.anInt1527); entity.anInt1527++) {
-				entity.anInt1528 -= animation_3.method258(entity.anInt1527);
+                        for (entity.anInt1528++; entity.anInt1527 < animation_3.anInt352 && entity.anInt1528 > animation_3.getFrameDelay(entity.anInt1527); entity.anInt1527++) {
+                                entity.anInt1528 -= animation_3.getFrameDelay(entity.anInt1527);
 			}
 
 			if (entity.anInt1527 >= animation_3.anInt352) {
@@ -9185,8 +9185,8 @@ public class Game extends RSApplet {
 				}
 				if (l != -1) {
 					Animation animation = Animation.anims[l];
-					for (class9_1.anInt208 += i; class9_1.anInt208 > animation.method258(class9_1.anInt246);) {
-						class9_1.anInt208 -= animation.method258(class9_1.anInt246) + 1;
+                                        for (class9_1.anInt208 += i; class9_1.anInt208 > animation.getFrameDelay(class9_1.anInt246);) {
+                                                class9_1.anInt208 -= animation.getFrameDelay(class9_1.anInt246) + 1;
 						class9_1.anInt246++;
 						if (class9_1.anInt246 >= animation.anInt352) {
 							class9_1.anInt246 -= animation.anInt356;

--- a/2006Scape Client/src/main/java/GraphicsObject.java
+++ b/2006Scape Client/src/main/java/GraphicsObject.java
@@ -51,8 +51,8 @@ final class GraphicsObject extends Animable {
     }
 
     public void update(int elapsed) {
-        for (frameCycle += elapsed; frameCycle > spotAnimation.aAnimation_407.method258(frame); ) {
-            frameCycle -= spotAnimation.aAnimation_407.method258(frame) + 1;
+        for (frameCycle += elapsed; frameCycle > spotAnimation.aAnimation_407.getFrameDelay(frame); ) {
+            frameCycle -= spotAnimation.aAnimation_407.getFrameDelay(frame) + 1;
             frame++;
             if (frame >= spotAnimation.aAnimation_407.anInt352 && (frame < 0 || frame >= spotAnimation.aAnimation_407.anInt352)) {
                 frame = 0;

--- a/2006Scape Client/src/main/java/IDK.java
+++ b/2006Scape Client/src/main/java/IDK.java
@@ -65,16 +65,16 @@ public final class IDK {
                 if (modelIds == null) {
                         return null;
                 }
-                Model aclass30_sub2_sub4_sub6s[] = new Model[modelIds.length];
+                Model[] models = new Model[modelIds.length];
                 for (int i = 0; i < modelIds.length; i++) {
-                        aclass30_sub2_sub4_sub6s[i] = Model.create(modelIds[i]);
+                        models[i] = Model.create(modelIds[i]);
                 }
 
-		Model model;
-                if (aclass30_sub2_sub4_sub6s.length == 1) {
-                        model = aclass30_sub2_sub4_sub6s[0];
+                Model model;
+                if (models.length == 1) {
+                        model = models[0];
                 } else {
-                        model = new Model(aclass30_sub2_sub4_sub6s.length, aclass30_sub2_sub4_sub6s);
+                        model = new Model(models.length, models);
                 }
                 for (int j = 0; j < 6; j++) {
                         if (recolorOriginal[j] == 0) {
@@ -98,15 +98,15 @@ public final class IDK {
 	}
 
         public Model getHeadModel() {
-                Model aclass30_sub2_sub4_sub6s[] = new Model[5];
+                Model[] models = new Model[5];
                 int j = 0;
                 for (int k = 0; k < 5; k++) {
                         if (headModelIds[k] != -1) {
-                                aclass30_sub2_sub4_sub6s[j++] = Model.create(headModelIds[k]);
+                                models[j++] = Model.create(headModelIds[k]);
                         }
                 }
 
-                Model model = new Model(j, aclass30_sub2_sub4_sub6s);
+                Model model = new Model(j, models);
                 for (int l = 0; l < 6; l++) {
                         if (recolorOriginal[l] == 0) {
                                 break;

--- a/2006Scape Client/src/main/java/Projectile.java
+++ b/2006Scape Client/src/main/java/Projectile.java
@@ -73,8 +73,8 @@ final class Projectile extends Animable {
                 yaw = (int) (Math.atan2(speedX, speedY) * 325.94900000000001D) + 1024 & 0x7ff;
                 pitch = (int) (Math.atan2(speedZ, speed) * 325.94900000000001D) & 0x7ff;
                 if (spotAnim.aAnimation_407 != null) {
-                        for (frameCycle += elapsed; frameCycle > spotAnim.aAnimation_407.method258(frame);) {
-                                frameCycle -= spotAnim.aAnimation_407.method258(frame) + 1;
+                        for (frameCycle += elapsed; frameCycle > spotAnim.aAnimation_407.getFrameDelay(frame);) {
+                                frameCycle -= spotAnim.aAnimation_407.getFrameDelay(frame) + 1;
                                 frame++;
                                 if (frame >= spotAnim.aAnimation_407.anInt352) {
                                         frame = 0;


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes             | ❌ |
| ≥ 80 % coverage on touched lines    | ❌ |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Rename obfuscated method `method258` in `Animation` to `getFrameDelay` and update all usages. Also rename local arrays `aclass30_sub2_sub4_sub6s` to `models` in `IDK` for clarity.

## 🗂️ Detailed Changes
- Introduced `getFrameDelay` replacing `method258` in `Animation`.
- Updated calls in `DynamicObject`, `Game`, `GraphicsObject`, and `Projectile`.
- Renamed temporary arrays to `models` within `IDK`'s `getBodyModel` and `getHeadModel` methods.

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| `method258` | `getFrameDelay` |
| `aclass30_sub2_sub4_sub6s` | `models` |

- **Batch**: N/A
- **Revert command**: `git revert -m 1 94569f7a`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Animation.java      | 26 +++++++++++-----------
 2006Scape Client/src/main/java/DynamicObject.java  |  6 ++---
 2006Scape Client/src/main/java/Game.java           | 16 ++++++-------
 2006Scape Client/src/main/java/GraphicsObject.java |  4 ++--
 2006Scape Client/src/main/java/IDK.java            | 18 +++++++--------
 2006Scape Client/src/main/java/Projectile.java     |  4 ++--
 6 files changed, 37 insertions(+), 37 deletions(-)
```

## 🧪 Integration-Test Log
Compilation via the AGENTS.md command completed with warnings but no errors.

## 📝 Rollback Plan
If this PR causes issues on `main`, run `git revert -m 1 94569f7a` to revert.


------
https://chatgpt.com/codex/tasks/task_e_68657f06675c832babffd5431c9bb8e8