### PR TITLE
[BOT] refactor(rename): clarify StreamLoader fields

### DIFF
--- a/2006Scape Client/src/main/java/Animation.java
+++ b/2006Scape Client/src/main/java/Animation.java
@@ -5,7 +5,7 @@
 public final class Animation {
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("seq.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("seq.dat"));
 		int length = stream.readUnsignedWord();
 		if (anims == null) {
 			anims = new Animation[length];

--- a/2006Scape Client/src/main/java/Background.java
+++ b/2006Scape Client/src/main/java/Background.java
@@ -5,8 +5,8 @@
 public final class Background extends DrawingArea {
 
         public Background(StreamLoader streamLoader, String s, int i) {
-		Stream stream = new Stream(streamLoader.getDataForName(s + ".dat"));
-		Stream stream_1 = new Stream(streamLoader.getDataForName("index.dat"));
+		Stream stream = new Stream(streamLoader.getFileData(s + ".dat"));
+		Stream stream_1 = new Stream(streamLoader.getFileData("index.dat"));
 		stream_1.currentOffset = stream.readUnsignedWord();
                 maxWidth = stream_1.readUnsignedWord();
                 maxHeight = stream_1.readUnsignedWord();

--- a/2006Scape Client/src/main/java/Censor.java
+++ b/2006Scape Client/src/main/java/Censor.java
@@ -5,10 +5,10 @@
 final class Censor {
 
 	public static void loadConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("fragmentsenc.txt"));
-		Stream stream_1 = new Stream(streamLoader.getDataForName("badenc.txt"));
-		Stream stream_2 = new Stream(streamLoader.getDataForName("domainenc.txt"));
-		Stream stream_3 = new Stream(streamLoader.getDataForName("tldlist.txt"));
+		Stream stream = new Stream(streamLoader.getFileData("fragmentsenc.txt"));
+		Stream stream_1 = new Stream(streamLoader.getFileData("badenc.txt"));
+		Stream stream_2 = new Stream(streamLoader.getFileData("domainenc.txt"));
+		Stream stream_3 = new Stream(streamLoader.getFileData("tldlist.txt"));
 		readValues(stream, stream_1, stream_2, stream_3);
 	}
 

--- a/2006Scape Client/src/main/java/EntityDef.java
+++ b/2006Scape Client/src/main/java/EntityDef.java
@@ -95,8 +95,8 @@ public final class EntityDef {
 	public static int totalNPCs;
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		stream = new Stream(streamLoader.getDataForName("npc.dat"));
-		Stream stream2 = new Stream(streamLoader.getDataForName("npc.idx"));
+		stream = new Stream(streamLoader.getFileData("npc.dat"));
+		Stream stream2 = new Stream(streamLoader.getFileData("npc.idx"));
 		totalNPCs = stream2.readUnsignedWord();
 		streamIndices = new int[totalNPCs];
 		int i = 2;

--- a/2006Scape Client/src/main/java/FloorOverlay.java
+++ b/2006Scape Client/src/main/java/FloorOverlay.java
@@ -8,7 +8,7 @@ import java.util.GregorianCalendar;
 public final class FloorOverlay {
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("flo.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("flo.dat"));
 		int cacheSize = stream.readUnsignedWord();
 		if (cache == null) {
 			cache = new FloorOverlay[cacheSize];

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -2773,7 +2773,7 @@ public class Game extends RSApplet {
 	}
 
 	public void drawLogo() {
-		byte abyte0[] = titleStreamLoader.getDataForName("title.dat");
+		byte abyte0[] = titleStreamLoader.getFileData("title.dat");
 		Sprite sprite = new Sprite(abyte0, this);
 		aRSImageProducer_1110.initDrawingArea();
 		sprite.drawSprite(0, 0);
@@ -7292,7 +7292,7 @@ public class Game extends RSApplet {
 			ItemDef.isMembers = isMembers;
 			// if (!lowMem) {
 			drawLoadingText(90, "Unpacking sounds");
-			byte abyte0[] = streamLoader_5.getDataForName("sounds.dat");
+			byte abyte0[] = streamLoader_5.getFileData("sounds.dat");
 			Stream stream = new Stream(abyte0);
 			Sounds.unpack(stream);
 			// }

--- a/2006Scape Client/src/main/java/IDK.java
+++ b/2006Scape Client/src/main/java/IDK.java
@@ -5,7 +5,7 @@
 public final class IDK {
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("idk.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("idk.dat"));
 		length = stream.readUnsignedWord();
 		if (cache == null) {
 			cache = new IDK[length];

--- a/2006Scape Client/src/main/java/ItemDef.java
+++ b/2006Scape Client/src/main/java/ItemDef.java
@@ -33,8 +33,8 @@ public final class ItemDef {
        }
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		stream = new Stream(streamLoader.getDataForName("obj.dat"));
-		Stream stream = new Stream(streamLoader.getDataForName("obj.idx"));
+		stream = new Stream(streamLoader.getFileData("obj.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("obj.idx"));
 		totalItems = stream.readUnsignedWord();
 		streamIndices = new int[totalItems];
 		int i = 2;

--- a/2006Scape Client/src/main/java/ObjectDef.java
+++ b/2006Scape Client/src/main/java/ObjectDef.java
@@ -86,8 +86,8 @@ public final class ObjectDef {
 	public static int totalObjects;
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		stream = new Stream(streamLoader.getDataForName("loc.dat"));
-		Stream stream = new Stream(streamLoader.getDataForName("loc.idx"));
+		stream = new Stream(streamLoader.getFileData("loc.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("loc.idx"));
 		totalObjects = stream.readUnsignedWord();
 		streamIndices = new int[totalObjects];
 		int i = 2;

--- a/2006Scape Client/src/main/java/OnDemandFetcher.java
+++ b/2006Scape Client/src/main/java/OnDemandFetcher.java
@@ -133,7 +133,7 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 	public void start(StreamLoader streamLoader, Game client1) {
 		String as[] = {"model_version", "anim_version", "midi_version", "map_version"};
 		for (int i = 0; i < 4; i++) {
-			byte abyte0[] = streamLoader.getDataForName(as[i]);
+			byte abyte0[] = streamLoader.getFileData(as[i]);
 			int j = abyte0.length / 2;
 			Stream stream = new Stream(abyte0);
 			versions[i] = new int[j];
@@ -146,7 +146,7 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 
 		String as1[] = {"model_crc", "anim_crc", "midi_crc", "map_crc"};
 		for (int k = 0; k < 4; k++) {
-			byte abyte1[] = streamLoader.getDataForName(as1[k]);
+			byte abyte1[] = streamLoader.getFileData(as1[k]);
 			int i1 = abyte1.length / 4;
 			Stream stream_1 = new Stream(abyte1);
 			crcs[k] = new int[i1];
@@ -156,7 +156,7 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 
 		}
 
-		byte abyte2[] = streamLoader.getDataForName("model_index");
+		byte abyte2[] = streamLoader.getFileData("model_index");
 		int j1 = versions[0].length;
 		modelIndices = new byte[j1];
 		for (int k1 = 0; k1 < j1; k1++) {
@@ -167,7 +167,7 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 			}
 		}
 
-		abyte2 = streamLoader.getDataForName("map_index");
+		abyte2 = streamLoader.getFileData("map_index");
 		Stream stream2 = new Stream(abyte2);
                 j1 = abyte2.length / 7;
                 regionIds = new int[j1];
@@ -181,7 +181,7 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
                         mapMembershipFlags[i2] = stream2.readUnsignedByte();
                 }
 
-		abyte2 = streamLoader.getDataForName("anim_index");
+		abyte2 = streamLoader.getFileData("anim_index");
 		stream2 = new Stream(abyte2);
 		j1 = abyte2.length / 2;
 		anIntArray1360 = new int[j1];
@@ -189,7 +189,7 @@ public final class OnDemandFetcher extends OnDemandFetcherParent implements Runn
 			anIntArray1360[j2] = stream2.readUnsignedWord();
 		}
 
-		abyte2 = streamLoader.getDataForName("midi_index");
+		abyte2 = streamLoader.getFileData("midi_index");
 		stream2 = new Stream(abyte2);
 		j1 = abyte2.length;
 		anIntArray1348 = new int[j1];

--- a/2006Scape Client/src/main/java/RSInterface.java
+++ b/2006Scape Client/src/main/java/RSInterface.java
@@ -11,7 +11,7 @@ public final class RSInterface {
 	
 	public static void unpack(StreamLoader streamLoader, TextDrawingArea textDrawingAreas[], StreamLoader streamLoader_1) {
                spriteCache = new MRUNodes(50000);
-		Stream stream = new Stream(streamLoader.getDataForName("data"));
+		Stream stream = new Stream(streamLoader.getFileData("data"));
 		int i = -1;
 		int j = stream.readUnsignedWord();
 		interfaceCache = new RSInterface[j];

--- a/2006Scape Client/src/main/java/SpotAnim.java
+++ b/2006Scape Client/src/main/java/SpotAnim.java
@@ -5,7 +5,7 @@
 public final class SpotAnim {
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("spotanim.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("spotanim.dat"));
 		int length = stream.readUnsignedWord();
 		if (cache == null) {
 			cache = new SpotAnim[length];

--- a/2006Scape Client/src/main/java/Sprite.java
+++ b/2006Scape Client/src/main/java/Sprite.java
@@ -40,8 +40,8 @@ public final class Sprite extends DrawingArea {
 	}
 
 	public Sprite(StreamLoader streamLoader, String s, int i) {
-		Stream stream = new Stream(streamLoader.getDataForName(s + ".dat"));
-		Stream stream_1 = new Stream(streamLoader.getDataForName("index.dat"));
+		Stream stream = new Stream(streamLoader.getFileData(s + ".dat"));
+		Stream stream_1 = new Stream(streamLoader.getFileData("index.dat"));
 		stream_1.currentOffset = stream.readUnsignedWord();
 		trimWidth = stream_1.readUnsignedWord();
 		trimHeight = stream_1.readUnsignedWord();

--- a/2006Scape Client/src/main/java/StreamLoader.java
+++ b/2006Scape Client/src/main/java/StreamLoader.java
@@ -5,65 +5,65 @@
 final class StreamLoader {
 
 	public StreamLoader(byte abyte0[]) {
-		Stream stream = new Stream(abyte0);
+                Stream stream = new Stream(abyte0);
 		int i = stream.read3Bytes();
 		int j = stream.read3Bytes();
 		if (j != i) {
-			byte abyte1[] = new byte[i];
-			BZip2Decompressor.decompress(abyte1, i, abyte0, j, 6);
-			aByteArray726 = abyte1;
-			stream = new Stream(aByteArray726);
-			aBoolean732 = true;
-		} else {
-			aByteArray726 = abyte0;
-			aBoolean732 = false;
-		}
-		dataSize = stream.readUnsignedWord();
-		anIntArray728 = new int[dataSize];
-		anIntArray729 = new int[dataSize];
-		anIntArray730 = new int[dataSize];
-		anIntArray731 = new int[dataSize];
-		int k = stream.currentOffset + dataSize * 10;
-		for (int l = 0; l < dataSize; l++) {
-			anIntArray728[l] = stream.readDWord();
-			anIntArray729[l] = stream.read3Bytes();
-			anIntArray730[l] = stream.read3Bytes();
-			anIntArray731[l] = k;
-			k += anIntArray730[l];
-		}
-	}
+                        byte abyte1[] = new byte[i];
+                        BZip2Decompressor.decompress(abyte1, i, abyte0, j, 6);
+                        dataBuffer = abyte1;
+                        stream = new Stream(dataBuffer);
+                        usesCompression = true;
+                } else {
+                        dataBuffer = abyte0;
+                        usesCompression = false;
+                }
+                fileCount = stream.readUnsignedWord();
+                fileHashes = new int[fileCount];
+                uncompressedSizes = new int[fileCount];
+                compressedSizes = new int[fileCount];
+                fileOffsets = new int[fileCount];
+                int k = stream.currentOffset + fileCount * 10;
+                for (int l = 0; l < fileCount; l++) {
+                        fileHashes[l] = stream.readDWord();
+                        uncompressedSizes[l] = stream.read3Bytes();
+                        compressedSizes[l] = stream.read3Bytes();
+                        fileOffsets[l] = k;
+                        k += compressedSizes[l];
+                }
+        }
 
-	public byte[] getDataForName(String s) {
-		byte abyte0[] = null; // was a parameter
-		int i = 0;
-		s = s.toUpperCase();
-		for (int j = 0; j < s.length(); j++) {
-			i = i * 61 + s.charAt(j) - 32;
-		}
+        public byte[] getFileData(String s) {
+                byte abyte0[] = null; // was a parameter
+                int i = 0;
+                s = s.toUpperCase();
+                for (int j = 0; j < s.length(); j++) {
+                        i = i * 61 + s.charAt(j) - 32;
+                }
 
-		for (int k = 0; k < dataSize; k++) {
-			if (anIntArray728[k] == i) {
-				if (abyte0 == null) {
-					abyte0 = new byte[anIntArray729[k]];
-				}
-				if (!aBoolean732) {
-					BZip2Decompressor.decompress(abyte0, anIntArray729[k], aByteArray726, anIntArray730[k], anIntArray731[k]);
-				} else {
-					System.arraycopy(aByteArray726, anIntArray731[k], abyte0, 0, anIntArray729[k]);
+                for (int k = 0; k < fileCount; k++) {
+                        if (fileHashes[k] == i) {
+                                if (abyte0 == null) {
+                                        abyte0 = new byte[uncompressedSizes[k]];
+                                }
+                                if (!usesCompression) {
+                                        BZip2Decompressor.decompress(abyte0, uncompressedSizes[k], dataBuffer, compressedSizes[k], fileOffsets[k]);
+                                } else {
+                                        System.arraycopy(dataBuffer, fileOffsets[k], abyte0, 0, uncompressedSizes[k]);
 
-				}
-				return abyte0;
-			}
-		}
+                                }
+                                return abyte0;
+                        }
+                }
 
 		return null;
 	}
 
-	private final byte[] aByteArray726;
-	private final int dataSize;
-	private final int[] anIntArray728;
-	private final int[] anIntArray729;
-	private final int[] anIntArray730;
-	private final int[] anIntArray731;
-	private final boolean aBoolean732;
+        private final byte[] dataBuffer;
+        private final int fileCount;
+        private final int[] fileHashes;
+        private final int[] uncompressedSizes;
+        private final int[] compressedSizes;
+        private final int[] fileOffsets;
+        private final boolean usesCompression;
 }

--- a/2006Scape Client/src/main/java/TextDrawingArea.java
+++ b/2006Scape Client/src/main/java/TextDrawingArea.java
@@ -15,8 +15,8 @@ public final class TextDrawingArea extends DrawingArea {
                 glyphAdvances = new int[256];
                 random = new Random();
                 strikethrough = false;
-		Stream stream = new Stream(streamLoader.getDataForName(s + ".dat"));
-		Stream stream_1 = new Stream(streamLoader.getDataForName("index.dat"));
+		Stream stream = new Stream(streamLoader.getFileData(s + ".dat"));
+		Stream stream_1 = new Stream(streamLoader.getFileData("index.dat"));
 		stream_1.currentOffset = stream.readUnsignedWord() + 4;
 		int k = stream_1.readUnsignedByte();
 		if (k > 0) {

--- a/2006Scape Client/src/main/java/VarBit.java
+++ b/2006Scape Client/src/main/java/VarBit.java
@@ -5,7 +5,7 @@
 public final class VarBit {
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("varbit.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("varbit.dat"));
 		int cacheSize = stream.readUnsignedWord();
 		if (cache == null) {
 			cache = new VarBit[cacheSize];

--- a/2006Scape Client/src/main/java/Varp.java
+++ b/2006Scape Client/src/main/java/Varp.java
@@ -5,7 +5,7 @@
 public final class Varp {
 
 	public static void unpackConfig(StreamLoader streamLoader) {
-		Stream stream = new Stream(streamLoader.getDataForName("varp.dat"));
+		Stream stream = new Stream(streamLoader.getFileData("varp.dat"));
                 varpCount = 0;
 		int cacheSize = stream.readUnsignedWord();
 		if (cache == null) {


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ❌ (17 files) |
| Branch rebased onto latest `main`   | ❌ (no remote) |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Refactors `StreamLoader` field names to more meaningful identifiers and updates the method `getDataForName` to `getFileData`. All client uses were updated accordingly for clarity.

## 🗂️ Detailed Changes
- Renamed internal fields in `StreamLoader` for better readability
- Updated `getDataForName` → `getFileData`
- Replaced all usages across the client

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| aByteArray726 | dataBuffer |
| dataSize | fileCount |
| anIntArray728 | fileHashes |
| anIntArray729 | uncompressedSizes |
| anIntArray730 | compressedSizes |
| anIntArray731 | fileOffsets |
| aBoolean732 | usesCompression |
| getDataForName | getFileData |

- **Batch**: N/A
- **Revert command**: `git revert -m 1 7650c435`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/Animation.java      |   2 +-
 2006Scape Client/src/main/java/Background.java     |   4 +-
 2006Scape Client/src/main/java/Censor.java         |   8 +-
 2006Scape Client/src/main/java/EntityDef.java      |   4 +-
 2006Scape Client/src/main/java/FloorOverlay.java   |   2 +-
 2006Scape Client/src/main/java/Game.java           |   4 +-
 2006Scape Client/src/main/java/IDK.java            |   2 +-
 2006Scape Client/src/main/java/ItemDef.java        |   4 +-
 2006Scape Client/src/main/java/ObjectDef.java      |   4 +-
 .../src/main/java/OnDemandFetcher.java             |  12 +--
 2006Scape Client/src/main/java/RSInterface.java    |   2 +-
 2006Scape Client/src/main/java/SpotAnim.java       |   2 +-
 2006Scape Client/src/main/java/Sprite.java         |   4 +-
 2006Scape Client/src/main/java/StreamLoader.java   | 102 ++++++++++-----------
 .../src/main/java/TextDrawingArea.java             |   4 +-
 2006Scape Client/src/main/java/VarBit.java         |   2 +-
 2006Scape Client/src/main/java/Varp.java           |   2 +-
 17 files changed, 82 insertions(+), 82 deletions(-)
```

## 🧪 Integration-Test Log
Compilation via `javac` succeeded with warnings.

## 📝 Rollback Plan
Use the revert command above if needed.


------
https://chatgpt.com/codex/tasks/task_e_68659c9a13a4832bbecaebf6d1a253d7