### PR TITLE
[BOT] refactor(rename): SpotAnim → descriptive fields

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -860,7 +860,7 @@ public class Game extends RSApplet {
             ItemDef.modelCache.unlinkAll();
             ItemDef.spriteCache.unlinkAll();
 		Player.mruNodes.unlinkAll();
-            SpotAnim.aMRUCache_415.unlinkAll();
+            SpotAnim.modelCache.unlinkAll();
 	}
 
        public void generateMinimap(int i) {
@@ -4797,7 +4797,7 @@ public class Game extends RSApplet {
 		CachePlaceholder.cache = null;
 		Animation.anims = null;
 		SpotAnim.cache = null;
-           SpotAnim.aMRUCache_415 = null;
+           SpotAnim.modelCache = null;
 		Varp.cache = null;
 		super.fullGameScreen = null;
 		Player.mruNodes = null;
@@ -7819,7 +7819,7 @@ public class Game extends RSApplet {
                        if (entity.spotAnimFrame < 0) {
                                entity.spotAnimFrame = 0;
                        }
-                       Animation animation_1 = SpotAnim.cache[entity.spotAnimId].aAnimation_407;
+                       Animation animation_1 = SpotAnim.cache[entity.spotAnimId].animation;
                        for (entity.spotAnimFrameCycle++; entity.spotAnimFrame < animation_1.anInt352 && entity.spotAnimFrameCycle > animation_1.getFrameDelay(entity.spotAnimFrame); entity.spotAnimFrame++) {
                                entity.spotAnimFrameCycle -= animation_1.getFrameDelay(entity.spotAnimFrame);
                        }

--- a/2006Scape Client/src/main/java/GraphicsObject.java
+++ b/2006Scape Client/src/main/java/GraphicsObject.java
@@ -21,7 +21,7 @@ final class GraphicsObject extends Animable {
         if (model == null) {
             return null;
         }
-        int   j       = spotAnimation.aAnimation_407.anIntArray353[frame];
+        int   j       = spotAnimation.animation.anIntArray353[frame];
         Model model_1 = new Model(true, AnimFrame.isNullFrame(j), false, model);
         if (!finished) {
             model_1.buildVertexGroups();
@@ -29,32 +29,32 @@ final class GraphicsObject extends Animable {
             model_1.faceGroups = null;
             model_1.vertexGroups = null;
         }
-        if (spotAnimation.anInt410 != 128 || spotAnimation.anInt411 != 128) {
-            model_1.scaleModel(spotAnimation.anInt410, spotAnimation.anInt410, spotAnimation.anInt411);
+        if (spotAnimation.scaleX != 128 || spotAnimation.scaleY != 128) {
+            model_1.scaleModel(spotAnimation.scaleX, spotAnimation.scaleX, spotAnimation.scaleY);
         }
-        if (spotAnimation.anInt412 != 0) {
-            if (spotAnimation.anInt412 == 90) {
+        if (spotAnimation.rotation != 0) {
+            if (spotAnimation.rotation == 90) {
                 model_1.calculateNormals();
             }
-            if (spotAnimation.anInt412 == 180) {
+            if (spotAnimation.rotation == 180) {
                 model_1.calculateNormals();
                 model_1.calculateNormals();
             }
-            if (spotAnimation.anInt412 == 270) {
+            if (spotAnimation.rotation == 270) {
                 model_1.calculateNormals();
                 model_1.calculateNormals();
                 model_1.calculateNormals();
             }
         }
-        model_1.applyLighting(64 + spotAnimation.anInt413, 850 + spotAnimation.anInt414, -30, -50, -30, true);
+        model_1.applyLighting(64 + spotAnimation.ambient, 850 + spotAnimation.contrast, -30, -50, -30, true);
         return model_1;
     }
 
     public void update(int elapsed) {
-        for (frameCycle += elapsed; frameCycle > spotAnimation.aAnimation_407.getFrameDelay(frame); ) {
-            frameCycle -= spotAnimation.aAnimation_407.getFrameDelay(frame) + 1;
+        for (frameCycle += elapsed; frameCycle > spotAnimation.animation.getFrameDelay(frame); ) {
+            frameCycle -= spotAnimation.animation.getFrameDelay(frame) + 1;
             frame++;
-            if (frame >= spotAnimation.aAnimation_407.anInt352 && (frame < 0 || frame >= spotAnimation.aAnimation_407.anInt352)) {
+            if (frame >= spotAnimation.animation.anInt352 && (frame < 0 || frame >= spotAnimation.animation.anInt352)) {
                 frame = 0;
                 finished = true;
             }

--- a/2006Scape Client/src/main/java/NPC.java
+++ b/2006Scape Client/src/main/java/NPC.java
@@ -34,17 +34,17 @@ public final class NPC extends Entity {
                        SpotAnim spotAnim = SpotAnim.cache[super.spotAnimId];
 			Model model_1 = spotAnim.getModel();
 			if (model_1 != null) {
-                               int j = spotAnim.aAnimation_407.anIntArray353[super.spotAnimFrame];
+                       int j = spotAnim.animation.anIntArray353[super.spotAnimFrame];
                                Model model_2 = new Model(true, AnimFrame.isNullFrame(j), false, model_1);
                                model_2.translate(0, -super.spotAnimHeight, 0);
 				model_2.buildVertexGroups();
 				model_2.applyFrame(j);
 				model_2.faceGroups = null;
 				model_2.vertexGroups = null;
-				if (spotAnim.anInt410 != 128 || spotAnim.anInt411 != 128) {
-					model_2.scaleModel(spotAnim.anInt410, spotAnim.anInt410, spotAnim.anInt411);
-				}
-				model_2.applyLighting(64 + spotAnim.anInt413, 850 + spotAnim.anInt414, -30, -50, -30, true);
+                                if (spotAnim.scaleX != 128 || spotAnim.scaleY != 128) {
+                                        model_2.scaleModel(spotAnim.scaleX, spotAnim.scaleX, spotAnim.scaleY);
+                                }
+                                model_2.applyLighting(64 + spotAnim.ambient, 850 + spotAnim.contrast, -30, -50, -30, true);
 				Model aModel[] = {model, model_2};
 				model = new Model(aModel);
 			}

--- a/2006Scape Client/src/main/java/Player.java
+++ b/2006Scape Client/src/main/java/Player.java
@@ -25,13 +25,13 @@ public final class Player extends Entity {
                                Model model_3 = new Model(true, AnimFrame.isNullFrame(super.spotAnimFrame), false, model_2);
                                model_3.translate(0, -super.spotAnimHeight, 0);
 				model_3.buildVertexGroups();
-                               model_3.applyFrame(spotAnim.aAnimation_407.anIntArray353[super.spotAnimFrame]);
+                               model_3.applyFrame(spotAnim.animation.anIntArray353[super.spotAnimFrame]);
 				model_3.faceGroups = null;
 				model_3.vertexGroups = null;
-				if (spotAnim.anInt410 != 128 || spotAnim.anInt411 != 128) {
-					model_3.scaleModel(spotAnim.anInt410, spotAnim.anInt410, spotAnim.anInt411);
-				}
-				model_3.applyLighting(64 + spotAnim.anInt413, 850 + spotAnim.anInt414, -30, -50, -30, true);
+                                if (spotAnim.scaleX != 128 || spotAnim.scaleY != 128) {
+                                        model_3.scaleModel(spotAnim.scaleX, spotAnim.scaleX, spotAnim.scaleY);
+                                }
+                                model_3.applyLighting(64 + spotAnim.ambient, 850 + spotAnim.contrast, -30, -50, -30, true);
 				Model aclass30_sub2_sub4_sub6_1s[] = {model, model_3};
 				model = new Model(aclass30_sub2_sub4_sub6_1s);
 			}

--- a/2006Scape Client/src/main/java/Projectile.java
+++ b/2006Scape Client/src/main/java/Projectile.java
@@ -30,9 +30,9 @@ final class Projectile extends Animable {
 			return null;
 		}
 		int j = -1;
-		if (spotAnim.aAnimation_407 != null) {
-			j = spotAnim.aAnimation_407.anIntArray353[frame];
-		}
+                if (spotAnim.animation != null) {
+                        j = spotAnim.animation.anIntArray353[frame];
+                }
                 Model model_1 = new Model(true, AnimFrame.isNullFrame(j), false, model);
 		if (j != -1) {
 			model_1.buildVertexGroups();
@@ -40,11 +40,11 @@ final class Projectile extends Animable {
 			model_1.faceGroups = null;
 			model_1.vertexGroups = null;
 		}
-		if (spotAnim.anInt410 != 128 || spotAnim.anInt411 != 128) {
-			model_1.scaleModel(spotAnim.anInt410, spotAnim.anInt410, spotAnim.anInt411);
-		}
-		model_1.rotateX(pitch);
-		model_1.applyLighting(64 + spotAnim.anInt413, 850 + spotAnim.anInt414, -30, -50, -30, true);
+                if (spotAnim.scaleX != 128 || spotAnim.scaleY != 128) {
+                        model_1.scaleModel(spotAnim.scaleX, spotAnim.scaleX, spotAnim.scaleY);
+                }
+                model_1.rotateX(pitch);
+                model_1.applyLighting(64 + spotAnim.ambient, 850 + spotAnim.contrast, -30, -50, -30, true);
 		return model_1;
 	}
 
@@ -72,11 +72,11 @@ final class Projectile extends Animable {
                 speedZ += accelerationZ * elapsed;
                 yaw = (int) (Math.atan2(speedX, speedY) * 325.94900000000001D) + 1024 & 0x7ff;
                 pitch = (int) (Math.atan2(speedZ, speed) * 325.94900000000001D) & 0x7ff;
-                if (spotAnim.aAnimation_407 != null) {
-                        for (frameCycle += elapsed; frameCycle > spotAnim.aAnimation_407.getFrameDelay(frame);) {
-                                frameCycle -= spotAnim.aAnimation_407.getFrameDelay(frame) + 1;
+                if (spotAnim.animation != null) {
+                        for (frameCycle += elapsed; frameCycle > spotAnim.animation.getFrameDelay(frame);) {
+                                frameCycle -= spotAnim.animation.getFrameDelay(frame) + 1;
                                 frame++;
-                                if (frame >= spotAnim.aAnimation_407.anInt352) {
+                                if (frame >= spotAnim.animation.anInt352) {
                                         frame = 0;
                                 }
                         }

--- a/2006Scape Client/src/main/java/SpotAnim.java
+++ b/2006Scape Client/src/main/java/SpotAnim.java
@@ -14,9 +14,9 @@ public final class SpotAnim {
 			if (cache[j] == null) {
 				cache[j] = new SpotAnim();
 			}
-			cache[j].anInt404 = j;
-			cache[j].readValues(stream);
-		}
+                        cache[j].id = j;
+                        cache[j].readValues(stream);
+                }
 
 	}
 
@@ -27,71 +27,71 @@ public final class SpotAnim {
 				return;
 			}
 			if (i == 1) {
-				anInt405 = stream.readUnsignedWord();
+                                modelId = stream.readUnsignedWord();
 			} else if (i == 2) {
-				anInt406 = stream.readUnsignedWord();
-				if (Animation.anims != null) {
-					aAnimation_407 = Animation.anims[anInt406];
-				}
+                                animationId = stream.readUnsignedWord();
+                                if (Animation.anims != null) {
+                                        animation = Animation.anims[animationId];
+                                }
 			} else if (i == 4) {
-				anInt410 = stream.readUnsignedWord();
+                                scaleX = stream.readUnsignedWord();
 			} else if (i == 5) {
-				anInt411 = stream.readUnsignedWord();
+                                scaleY = stream.readUnsignedWord();
 			} else if (i == 6) {
-				anInt412 = stream.readUnsignedWord();
+                                rotation = stream.readUnsignedWord();
 			} else if (i == 7) {
-				anInt413 = stream.readUnsignedByte();
+                                ambient = stream.readUnsignedByte();
 			} else if (i == 8) {
-				anInt414 = stream.readUnsignedByte();
+                                contrast = stream.readUnsignedByte();
 			} else if (i >= 40 && i < 50) {
-				anIntArray408[i - 40] = stream.readUnsignedWord();
+                                originalModelColors[i - 40] = stream.readUnsignedWord();
 			} else if (i >= 50 && i < 60) {
-				anIntArray409[i - 50] = stream.readUnsignedWord();
+                                modifiedModelColors[i - 50] = stream.readUnsignedWord();
 			} else {
 				System.out.println("Error unrecognised spotanim config code: " + i);
 			}
 		} while (true);
 	}
 
-	public Model getModel() {
-                Model model = (Model) aMRUCache_415.get(anInt404);
-		if (model != null) {
-			return model;
-		}
-		model = Model.create(anInt405);
-		if (model == null) {
-			return null;
-		}
-		for (int i = 0; i < 6; i++) {
-			if (anIntArray408[0] != 0) {
-				model.recolor(anIntArray408[i], anIntArray409[i]);
-			}
-		}
+        public Model getModel() {
+                Model model = (Model) modelCache.get(id);
+                if (model != null) {
+                        return model;
+                }
+                model = Model.create(modelId);
+                if (model == null) {
+                        return null;
+                }
+                for (int i = 0; i < 6; i++) {
+                        if (originalModelColors[0] != 0) {
+                                model.recolor(originalModelColors[i], modifiedModelColors[i]);
+                        }
+                }
 
-                aMRUCache_415.put(model, anInt404);
-		return model;
-	}
+                modelCache.put(model, id);
+                return model;
+        }
 
 	private SpotAnim() {
-		anInt406 = -1;
-		anIntArray408 = new int[6];
-		anIntArray409 = new int[6];
-		anInt410 = 128;
-		anInt411 = 128;
-	}
+                animationId = -1;
+                originalModelColors = new int[6];
+                modifiedModelColors = new int[6];
+                scaleX = 128;
+                scaleY = 128;
+        }
 
-	public static SpotAnim cache[];
-	private int anInt404;
-	private int anInt405;
-	private int anInt406;
-	public Animation aAnimation_407;
-	private final int[] anIntArray408;
-	private final int[] anIntArray409;
-	public int anInt410;
-	public int anInt411;
-	public int anInt412;
-	public int anInt413;
-	public int anInt414;
-        public static MRUCache aMRUCache_415 = new MRUCache(30);
+        public static SpotAnim cache[];
+        private int id;
+        private int modelId;
+        private int animationId;
+        public Animation animation;
+        private final int[] originalModelColors;
+        private final int[] modifiedModelColors;
+        public int scaleX;
+        public int scaleY;
+        public int rotation;
+        public int ambient;
+        public int contrast;
+        public static MRUCache modelCache = new MRUCache(30);
 
 }


### PR DESCRIPTION
## Summary
- rename obfuscated fields in SpotAnim to meaningful names
- update all references across Projectile, GraphicsObject, NPC, Player and Game

| Old Name | New Name |
|---|---|
| `anInt404` | `id` |
| `anInt405` | `modelId` |
| `anInt406` | `animationId` |
| `aAnimation_407` | `animation` |
| `anIntArray408` | `originalModelColors` |
| `anIntArray409` | `modifiedModelColors` |
| `anInt410` | `scaleX` |
| `anInt411` | `scaleY` |
| `anInt412` | `rotation` |
| `anInt413` | `ambient` |
| `anInt414` | `contrast` |
| `aMRUCache_415` | `modelCache` |

`git diff --stat`:
```
 2006Scape Client/src/main/java/Game.java           |   6 +- 
 2006Scape Client/src/main/java/GraphicsObject.java |  22 ++---
 2006Scape Client/src/main/java/NPC.java            |  10 +- 
 2006Scape Client/src/main/java/Player.java         |  10 +- 
 2006Scape Client/src/main/java/Projectile.java     |  24 ++---
 2006Scape Client/src/main/java/SpotAnim.java       | 102 ++++++++++-----------
 6 files changed, 87 insertions(+), 87 deletions(-)
```

## Testing
- `git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac`


------
https://chatgpt.com/codex/tasks/task_e_6866f68e7b60832bbb47f5766bb8956b