### PR TITLE
[BOT] chore(config): use shared cache directory

### DIFF
--- a/2006Scape Client/src/main/java/Signlink.java
+++ b/2006Scape Client/src/main/java/Signlink.java
@@ -278,14 +278,14 @@ public final class Signlink implements Runnable {
 	public static Synthesizer synthesizer = null;
 
 	public static String findcachedir() {
-		String path = System.getProperty("user.home") + "/.2006Scape_file_system/";
-		File file = new File(path);
-		if (!file.exists()) {
-			if (!file.mkdirs()) {
-				return secondDir();
-			}
-		}
-		return path;
+                String path = "./.jagex_cache_32/runescape/";
+                File file = new File(path);
+                if (!file.exists()) {
+                        if (!file.mkdirs()) {
+                                return secondDir();
+                        }
+                }
+                return path;
 	}
 
 	public static String secondDir() {

--- a/2006Scape Server/src/main/java/com/rs2/Constants.java
+++ b/2006Scape Server/src/main/java/com/rs2/Constants.java
@@ -90,7 +90,7 @@ public class Constants {
     /**
      * The directory of the file system.
      */
-    public static final String FILE_SYSTEM_DIR = "./data/cache/";
+    public static final String FILE_SYSTEM_DIR = "./.jagex_cache_32/runescape/";
 
     public final static String SERVER_LOG_DIR = "./data/logs/";
 


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) |    |
| `spotbugs:check` passes             |    |
| ≥ 80 % coverage on touched lines    |    |
| Net Δ lines < 5 000                 |   ✅ |
| ≤ 10 files modified                 |   ✅ |
| Branch rebased onto latest `main`   |   ✅ |
| PR labeled `bot`                    |   ✅ |
| No new external dependencies        |   ✅ |

---

## 🔍 What & Why
Switch both the server and client to use the cache stored in `.jagex_cache_32/runescape/` so that the same files are shared. This updates `Constants.FILE_SYSTEM_DIR` and `Signlink.findcachedir()`.

---

## 🗂️ Detailed Changes
- Updated server constant `FILE_SYSTEM_DIR` to point at `./.jagex_cache_32/runescape/`.
- Modified client `findcachedir()` method to use the same directory instead of `~/.2006Scape_file_system/`.

```
$ git diff --stat HEAD~1 HEAD
```
```
 2006Scape Client/src/main/java/Signlink.java          | 16 ++++++++--------
 2006Scape Server/src/main/java/com/rs2/Constants.java |  2 +-
 2 files changed, 9 insertions(+), 9 deletions(-)
```

---

## 🧪 Integration-Test Log

```
$ git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac
```
Warnings only (deprecation), exit code 0.

---

## 📝 Rollback Plan
Revert with `git revert -m 1 5f4b743f` if issues occur.


------
https://chatgpt.com/codex/tasks/task_e_6867182a55ec832b9d61584d3e29400c