### PR TITLE
[BOT] refactor(rename): RSInterface fields

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -1059,10 +1059,10 @@ public class Game extends RSApplet {
 			int j2 = class9.childY[l1] + l - j1;
 			RSInterface class9_1 = RSInterface.interfaceCache[class9.children[l1]];
                         i2 += class9_1.offsetX;
-			j2 += class9_1.anInt265;
-			if ((class9_1.anInt230 >= 0 || class9_1.anInt216 != 0) && k >= i2 && i1 >= j2 && k < i2 + class9_1.width && i1 < j2 + class9_1.height) {
-				if (class9_1.anInt230 >= 0) {
-					hoveredWidgetId = class9_1.anInt230;
+			j2 += class9_1.offsetY;
+			if ((class9_1.hoverTarget >= 0 || class9_1.hoverTextColor != 0) && k >= i2 && i1 >= j2 && k < i2 + class9_1.width && i1 < j2 + class9_1.height) {
+				if (class9_1.hoverTarget >= 0) {
+					hoveredWidgetId = class9_1.hoverTarget;
 				} else {
 					hoveredWidgetId = class9_1.id;
 				}
@@ -1075,7 +1075,7 @@ public class Game extends RSApplet {
 			} else {
 				if (class9_1.atActionType == 1 && k >= i2 && i1 >= j2 && k < i2 + class9_1.width && i1 < j2 + class9_1.height) {
 					boolean flag = false;
-					if (class9_1.anInt214 != 0) {
+					if (class9_1.contentType != 0) {
 						flag = buildFriendsListMenu(class9_1);
 					}
 					if (!flag) {
@@ -1349,7 +1349,7 @@ public class Game extends RSApplet {
 					reportAbuseInput = "";
 					canMute = false;
 					for (RSInterface element : RSInterface.interfaceCache) {
-						if (element == null || element.anInt214 != 600) {
+						if (element == null || element.contentType != 600) {
 							continue;
 						}
 						reportAbuseInterfaceID = openInterfaceID = element.parentID;
@@ -2330,7 +2330,7 @@ public class Game extends RSApplet {
 	}
 
 	public boolean promptUserForInput(RSInterface class9) {
-		int j = class9.anInt214;
+		int j = class9.contentType;
 		if (interfaceMode == 2) {
 			if (j == 201) {
 				inputTaken = true;
@@ -2956,8 +2956,8 @@ public class Game extends RSApplet {
 			if (class9_1.type == 1) {
                                resetInterfaceAnimation(class9_1.id);
 			}
-			class9_1.anInt246 = 0;
-			class9_1.anInt208 = 0;
+                        class9_1.animationFrame = 0;
+                        class9_1.animationCycle = 0;
 		}
 	}
 
@@ -3159,7 +3159,7 @@ public class Game extends RSApplet {
 					if (lastActiveInvInterface == dragInterfaceId && mouseInvInterfaceIndex != draggedSlot) {
 						RSInterface class9 = RSInterface.interfaceCache[dragInterfaceId];
 						int j1 = 0;
-						if (configActionId == 1 && class9.anInt214 == 206) {
+						if (configActionId == 1 && class9.contentType == 206) {
 							j1 = 1;
 						}
 						if (class9.inv[mouseInvInterfaceIndex] <= 0) {
@@ -3710,7 +3710,7 @@ public class Game extends RSApplet {
 		if (l == 315) {
 			RSInterface class9 = RSInterface.interfaceCache[k];
 			boolean flag8 = true;
-			if (class9.anInt214 > 0) {
+			if (class9.contentType > 0) {
 				flag8 = promptUserForInput(class9);
 			}
 			if (flag8) {
@@ -4060,8 +4060,8 @@ public class Game extends RSApplet {
 			RSInterface class9_2 = RSInterface.interfaceCache[k];
 			if (class9_2.valueIndexArray != null && class9_2.valueIndexArray[0][0] == 5) {
 				int i2 = class9_2.valueIndexArray[0][1];
-				if (variousSettings[i2] != class9_2.anIntArray212[0]) {
-					variousSettings[i2] = class9_2.anIntArray212[0];
+				if (variousSettings[i2] != class9_2.requiredValues[0]) {
+					variousSettings[i2] = class9_2.requiredValues[0];
                                    applyVarp(i2);
 					needDrawTabArea = true;
 				}
@@ -4264,7 +4264,7 @@ public class Game extends RSApplet {
 					reportAbuseInput = s2.substring(j2 + 5).trim();
 					canMute = false;
 					for (RSInterface element : RSInterface.interfaceCache) {
-						if (element == null || element.anInt214 != 600) {
+						if (element == null || element.contentType != 600) {
 							continue;
 						}
 						reportAbuseInterfaceID = openInterfaceID = element.parentID;
@@ -5285,7 +5285,7 @@ public class Game extends RSApplet {
 	}
 
 	public void drawFriendsListOrWelcomeScreen(RSInterface class9) {
-		int j = class9.anInt214;
+		int j = class9.contentType;
 		if (j >= 1 && j <= 100 || j >= 701 && j <= 800) {
 			if (j == 1 && interfaceMode == 0) {
 				class9.disabledText = "Loading friend list";
@@ -8142,7 +8142,7 @@ public class Game extends RSApplet {
 	}
 
 	public boolean buildFriendsListMenu(RSInterface class9) {
-		int i = class9.anInt214;
+		int i = class9.contentType;
 		if (i >= 1 && i <= 200 || i >= 701 && i <= 900) {
 			if (i >= 801) {
 				i -= 701;
@@ -8206,8 +8206,8 @@ public class Game extends RSApplet {
 			int l2 = class9.childY[j2] + l - scrollPos;
 			RSInterface component = RSInterface.interfaceCache[class9.children[j2]];
                         k2 += component.offsetX;
-			l2 += component.anInt265;
-			if (component.anInt214 > 0) {
+			l2 += component.offsetY;
+			if (component.contentType > 0) {
 				drawFriendsListOrWelcomeScreen(component);
 			}
 			if (component.type == 0) {
@@ -8314,14 +8314,14 @@ public class Game extends RSApplet {
 					}
 					int color;
 					if (interfaceIsSelected(component)) {
-						color = component.anInt219;
-						if (flag && component.anInt239 != 0) {
-							color = component.anInt239;
+						color = component.activeTextColor;
+						if (flag && component.activeHoverTextColor != 0) {
+							color = component.activeHoverTextColor;
 						}
 					} else {
 						color = component.textColor;
-						if (flag && component.anInt216 != 0) {
-							color = component.anInt216;
+						if (flag && component.hoverTextColor != 0) {
+							color = component.hoverTextColor;
 						}
 					}
 					if (component.aByte254 == 0) {
@@ -8344,17 +8344,17 @@ public class Game extends RSApplet {
 					}
 					int i4;
 					if (interfaceIsSelected(component)) {
-						i4 = component.anInt219;
-						if (flag1 && component.anInt239 != 0) {
-							i4 = component.anInt239;
+						i4 = component.activeTextColor;
+						if (flag1 && component.activeHoverTextColor != 0) {
+							i4 = component.activeHoverTextColor;
 						}
 						if (component.enabledText.length() > 0) {
 							s = component.enabledText;
 						}
 					} else {
 						i4 = component.textColor;
-						if (flag1 && component.anInt216 != 0) {
-							i4 = component.anInt216;
+						if (flag1 && component.hoverTextColor != 0) {
+							i4 = component.hoverTextColor;
 						}
 					}
 					if (component.atActionType == 6 && actionPending) {
@@ -8452,7 +8452,7 @@ public class Game extends RSApplet {
                                                 model = component.prepareModel(-1, -1, flag2);
 					} else {
 						Animation animation = Animation.anims[i7];
-                                                model = component.prepareModel(animation.secondaryFrameIds[component.anInt246], animation.frameIds[component.anInt246], flag2);
+                                                model = component.prepareModel(animation.secondaryFrameIds[component.animationFrame], animation.frameIds[component.animationFrame], flag2);
 					}
                                         if (model != null) {
                                                 model.transformVertices(component.modelRotation2, 0, component.modelRotation1, 0, i5, l5);
@@ -9183,19 +9183,19 @@ public class Game extends RSApplet {
                                 } else {
                                         l = class9_1.disabledAnimation;
                                 }
-				if (l != -1) {
-					Animation animation = Animation.anims[l];
-                                        for (class9_1.anInt208 += i; class9_1.anInt208 > animation.getFrameDelay(class9_1.anInt246);) {
-                                                class9_1.anInt208 -= animation.getFrameDelay(class9_1.anInt246) + 1;
-						class9_1.anInt246++;
-						if (class9_1.anInt246 >= animation.frameCount) {
-							class9_1.anInt246 -= animation.frameStep;
-							if (class9_1.anInt246 < 0 || class9_1.anInt246 >= animation.frameCount) {
-								class9_1.anInt246 = 0;
-							}
-						}
-						flag1 = true;
-					}
+                                if (l != -1) {
+                                        Animation animation = Animation.anims[l];
+                                        for (class9_1.animationCycle += i; class9_1.animationCycle > animation.getFrameDelay(class9_1.animationFrame);) {
+                                                class9_1.animationCycle -= animation.getFrameDelay(class9_1.animationFrame) + 1;
+                                                class9_1.animationFrame++;
+                                                if (class9_1.animationFrame >= animation.frameCount) {
+                                                        class9_1.animationFrame -= animation.frameStep;
+                                                        if (class9_1.animationFrame < 0 || class9_1.animationFrame >= animation.frameCount) {
+                                                                class9_1.animationFrame = 0;
+                                                        }
+                                                }
+                                                flag1 = true;
+                                        }
 
 				}
 			}
@@ -9715,21 +9715,21 @@ public class Game extends RSApplet {
 	}
 
 	public boolean interfaceIsSelected(RSInterface class9) {
-		if (class9.anIntArray245 == null) {
+		if (class9.valueCompareType == null) {
 			return false;
 		}
-		for (int i = 0; i < class9.anIntArray245.length; i++) {
+		for (int i = 0; i < class9.valueCompareType.length; i++) {
 			int j = extractInterfaceValues(class9, i);
-			int k = class9.anIntArray212[i];
-			if (class9.anIntArray245[i] == 2) {
+			int k = class9.requiredValues[i];
+			if (class9.valueCompareType[i] == 2) {
 				if (j >= k) {
 					return false;
 				}
-			} else if (class9.anIntArray245[i] == 3) {
+			} else if (class9.valueCompareType[i] == 3) {
 				if (j <= k) {
 					return false;
 				}
-			} else if (class9.anIntArray245[i] == 4) {
+			} else if (class9.valueCompareType[i] == 4) {
 				if (j == k) {
 					return false;
 				}
@@ -10657,7 +10657,7 @@ public class Game extends RSApplet {
 					reportAbuseInput = "";
 					canMute = false;
 					for (RSInterface element : RSInterface.interfaceCache) {
-						if (element == null || element.anInt214 != c) {
+						if (element == null || element.contentType != c) {
 							continue;
 						}
 						openInterfaceID = element.parentID;
@@ -10815,7 +10815,7 @@ public class Game extends RSApplet {
 				int i16 = inStream.readShortLE();
                                 RSInterface class9_5 = RSInterface.interfaceCache[i16];
                                 class9_5.offsetX = k2;
-				class9_5.anInt265 = l10;
+				class9_5.offsetY = l10;
 				pktType = -1;
 				return true;
 			}
@@ -11725,10 +11725,10 @@ public class Game extends RSApplet {
 				int i15 = inStream.readSignedWord();
                                 RSInterface class9_4 = RSInterface.interfaceCache[l8];
                                 class9_4.disabledAnimation = i15;
-				if (i15 == -1) {
-					class9_4.anInt246 = 0;
-					class9_4.anInt208 = 0;
-				}
+                                if (i15 == -1) {
+                                        class9_4.animationFrame = 0;
+                                        class9_4.animationCycle = 0;
+                                }
 				pktType = -1;
 				return true;
 			}

--- a/2006Scape Client/src/main/java/RSInterface.java
+++ b/2006Scape Client/src/main/java/RSInterface.java
@@ -26,24 +26,24 @@ public final class RSInterface {
 			rsInterface.parentID = i;
 			rsInterface.type = stream.readUnsignedByte();
 			rsInterface.atActionType = stream.readUnsignedByte();
-			rsInterface.anInt214 = stream.readUnsignedWord();
+                        rsInterface.contentType = stream.readUnsignedWord();
 			rsInterface.width = stream.readUnsignedWord();
 			rsInterface.height = stream.readUnsignedWord();
 			rsInterface.aByte254 = (byte) stream.readUnsignedByte();
-			rsInterface.anInt230 = stream.readUnsignedByte();
-			if (rsInterface.anInt230 != 0) {
-				rsInterface.anInt230 = (rsInterface.anInt230 - 1 << 8) + stream.readUnsignedByte();
-			} else {
-				rsInterface.anInt230 = -1;
-			}
+                        rsInterface.hoverTarget = stream.readUnsignedByte();
+                        if (rsInterface.hoverTarget != 0) {
+                                rsInterface.hoverTarget = (rsInterface.hoverTarget - 1 << 8) + stream.readUnsignedByte();
+                        } else {
+                                rsInterface.hoverTarget = -1;
+                        }
 			int i1 = stream.readUnsignedByte();
-			if (i1 > 0) {
-				rsInterface.anIntArray245 = new int[i1];
-				rsInterface.anIntArray212 = new int[i1];
-				for (int j1 = 0; j1 < i1; j1++) {
-					rsInterface.anIntArray245[j1] = stream.readUnsignedByte();
-					rsInterface.anIntArray212[j1] = stream.readUnsignedWord();
-				}
+                        if (i1 > 0) {
+                                rsInterface.valueCompareType = new int[i1];
+                                rsInterface.requiredValues = new int[i1];
+                                for (int j1 = 0; j1 < i1; j1++) {
+                                        rsInterface.valueCompareType[j1] = stream.readUnsignedByte();
+                                        rsInterface.requiredValues[j1] = stream.readUnsignedWord();
+                                }
 
 			}
 			int k1 = stream.readUnsignedByte();
@@ -137,9 +137,9 @@ public final class RSInterface {
 				rsInterface.textColor = stream.readDWord();
 			}
 			if (rsInterface.type == 3 || rsInterface.type == 4) {
-				rsInterface.anInt219 = stream.readDWord();
-				rsInterface.anInt216 = stream.readDWord();
-				rsInterface.anInt239 = stream.readDWord();
+                                rsInterface.activeTextColor = stream.readDWord();
+                                rsInterface.hoverTextColor = stream.readDWord();
+                                rsInterface.activeHoverTextColor = stream.readDWord();
 			}
 			if (rsInterface.type == 5) {
 				String s = stream.readString();
@@ -322,16 +322,21 @@ public final class RSInterface {
 	}
 
 	public Sprite sprite1;
-	public int anInt208;
+        /** Animation cycle counter. */
+        public int animationCycle;
 	public Sprite sprites[];
 	public static RSInterface interfaceCache[];
-	public int anIntArray212[];
-	public int anInt214;
+        /** Values that must be matched for this widget to be considered selected. */
+        public int requiredValues[];
+        /** Content type used for client scripts. */
+        public int contentType;
 	public int spritesX[];
-	public int anInt216;
+        /** Text colour when hovered but not selected. */
+        public int hoverTextColor;
 	public int atActionType;
 	public String spellName;
-	public int anInt219;
+        /** Text colour when the widget is selected. */
+        public int activeTextColor;
 	public int width;
 	public String tooltip;
 	public String selectedActionName;
@@ -341,7 +346,8 @@ public final class RSInterface {
 	public int valueIndexArray[][];
 	public boolean aBoolean227;
 	public String enabledText;
-	public int anInt230;
+        /** ID of the widget to display when this widget is hovered. */
+        public int hoverTarget;
 	public int invSpritePadX;
 	public int textColor;
         public int mediaType;
@@ -350,14 +356,17 @@ public final class RSInterface {
 	public int parentID;
 	public int spellUsableOn;
         private static MRUCache spriteCache;
-	public int anInt239;
+        /** Text colour when selected and hovered. */
+        public int activeHoverTextColor;
 	public int children[];
 	public int childX[];
 	public boolean usableItemInterface;
 	public TextDrawingArea textDrawingAreas;
 	public int invSpritePadY;
-	public int anIntArray245[];
-	public int anInt246;
+        /** Comparator types used for the value comparison script. */
+        public int valueCompareType[];
+        /** Current animation frame. */
+        public int animationFrame;
 	public int spritesY[];
 	public String disabledText;
 	public boolean isInventoryInterface;
@@ -375,7 +384,8 @@ public final class RSInterface {
 	public int type;
         public int offsetX;
         private static final MRUCache modelCache = new MRUCache(30);
-	public int anInt265;
+        /** Vertical offset applied when rendering. */
+        public int offsetY;
 	public boolean aBoolean266;
 	public int height;
 	public static int shading;

--- a/rename-history.md
+++ b/rename-history.md
@@ -26,7 +26,17 @@ This document lists variable or identifier renames found in the commit history.
  - forID -> lookup
  - aMRUCache_415 -> modelCache
  - anInt413 -> ambient
- - anInt414 -> contrast
+- anInt414 -> contrast
+- anInt208 -> animationCycle
+- anInt214 -> contentType
+- anInt216 -> hoverTextColor
+- anInt219 -> activeTextColor
+- anInt230 -> hoverTarget
+- anInt239 -> activeHoverTextColor
+- anInt246 -> animationFrame
+- anInt265 -> offsetY
+- anIntArray212 -> requiredValues
+- anIntArray245 -> valueCompareType
 
 ## EntityDef
  - method464 -> copyFromModel


### PR DESCRIPTION
## Summary
- rename several RSInterface fields and arrays
- update references throughout the client
- record the renames in `rename-history.md`

### Renamed
| Old Name | New Name |
|----------|----------|
| `anInt208` | `animationCycle` |
| `anInt214` | `contentType` |
| `anInt216` | `hoverTextColor` |
| `anInt219` | `activeTextColor` |
| `anInt230` | `hoverTarget` |
| `anInt239` | `activeHoverTextColor` |
| `anInt246` | `animationFrame` |
| `anInt265` | `offsetY` |
| `anIntArray212` | `requiredValues` |
| `anIntArray245` | `valueCompareType` |

## Testing
- `git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac`


------
https://chatgpt.com/codex/tasks/task_e_68724eb79228832bbdf6de1a5c5ec370