### PR TITLE
[BOT] refactor(rename): clean numeric suffixes

### DIFF
--- a/2006Scape Client/src/main/java/Animation.java
+++ b/2006Scape Client/src/main/java/Animation.java
@@ -136,5 +136,5 @@ public final class Animation {
 	public int precedenceAnimating;
 	public int precedenceWalking;
 	public int replayMode;
-	public static int anInt367;
+        public static int animationCount;
 }

--- a/2006Scape Client/src/main/java/DrawingArea.java
+++ b/2006Scape Client/src/main/java/DrawingArea.java
@@ -46,8 +46,8 @@ public class DrawingArea extends NodeSub {
 		} else {
 			centerX = bottomX - 1;
 		}
-		centerY = bottomX / 2;
-		anInt1387 = bottomY / 2;
+                centerY = bottomX / 2;
+                viewportHalfHeight = bottomY / 2;
 	}
 
 	public static void setAllPixelsToZero() {
@@ -236,6 +236,6 @@ public class DrawingArea extends NodeSub {
 	public static int bottomX;
 	public static int centerX;
 	public static int centerY;
-	public static int anInt1387;
+        public static int viewportHalfHeight;
 
 }

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -1510,7 +1510,7 @@ public class Game extends RSApplet {
 				}
 			}
 			// Entity stuff
-			int anInt974 = 0;
+                        int overheadTextCount = 0;
 			for (int j = -1; j < playerCount + npcCount; j++) {
 				Object obj;
 				if (j == -1) {
@@ -1589,24 +1589,24 @@ public class Game extends RSApplet {
 				// Chat messages sent
 				if (((Entity) obj).textSpoken != null && (j >= playerCount || publicChatMode == 0 || publicChatMode == 3 || publicChatMode == 1 && isFriendOrSelf(((Player) obj).name))) {
 					npcScreenPos(((Entity) obj), ((Entity) obj).height);
-					if (spriteDrawX > -1 && anInt974 < maxDisplayedText) {
-                                                textWidth[anInt974] = chatTextDrawingArea.measurePlainTextWidth(((Entity) obj).textSpoken) / 2;
-                                                textHeight[anInt974] = chatTextDrawingArea.fontHeight;
-						textX[anInt974] = spriteDrawX;
-						textY[anInt974] = spriteDrawY;
-						textColors[anInt974] = ((Entity) obj).chatColor;
-						textEffects[anInt974] = ((Entity) obj).chatEffect;
-						textCycles[anInt974] = ((Entity) obj).textCycle;
-						overheadTexts[anInt974++] = ((Entity) obj).textSpoken;
+                                        if (spriteDrawX > -1 && overheadTextCount < maxDisplayedText) {
+                                                textWidth[overheadTextCount] = chatTextDrawingArea.measurePlainTextWidth(((Entity) obj).textSpoken) / 2;
+                                                textHeight[overheadTextCount] = chatTextDrawingArea.fontHeight;
+                                                textX[overheadTextCount] = spriteDrawX;
+                                                textY[overheadTextCount] = spriteDrawY;
+                                                textColors[overheadTextCount] = ((Entity) obj).chatColor;
+                                                textEffects[overheadTextCount] = ((Entity) obj).chatEffect;
+                                                textCycles[overheadTextCount] = ((Entity) obj).textCycle;
+                                                overheadTexts[overheadTextCount++] = ((Entity) obj).textSpoken;
 						if (chatEffectsState == 0 && ((Entity) obj).chatEffect >= 1 && ((Entity) obj).chatEffect <= 3) {
-							textHeight[anInt974] += 10;
-							textY[anInt974] += 5;
+                                                        textHeight[overheadTextCount] += 10;
+                                                        textY[overheadTextCount] += 5;
 						}
 						if (chatEffectsState == 0 && ((Entity) obj).chatEffect == 4) {
-							textWidth[anInt974] = 60;
+                                                        textWidth[overheadTextCount] = 60;
 						}
 						if (chatEffectsState == 0 && ((Entity) obj).chatEffect == 5) {
-							textHeight[anInt974] += 5;
+                                                        textHeight[overheadTextCount] += 5;
 						}
 					}
 				}
@@ -1649,7 +1649,7 @@ public class Game extends RSApplet {
 				}
 			}
 			// Hit markers
-			for (int k = 0; k < anInt974; k++) {
+                        for (int k = 0; k < overheadTextCount; k++) {
 				int k1 = textX[k];
 				int l1 = textY[k];
 				int j2 = textWidth[k];
@@ -2311,7 +2311,7 @@ public class Game extends RSApplet {
 			if (j1 < 0 || j1 >= 104 || k1 < 0 || k1 >= 104) {
 				continue;
 			}
-                        if (player.aModel_1714 != null && loopCycle >= player.animationStartCycle && loopCycle < player.animationEndCycle) {
+                        if (player.overlayModel != null && loopCycle >= player.animationStartCycle && loopCycle < player.animationEndCycle) {
 				player.skipAnimations = false;
                                 player.animationBaseY = getTileHeight(plane, player.y, player.x);
                                worldController.addAnimatingObject(plane, player.y, player, player.currentHeading, player.boundingBoxMaxY, player.x, player.animationBaseY, player.boundingBoxMinX, player.boundingBoxMaxX, i1, player.boundingBoxMinY);
@@ -7004,7 +7004,7 @@ public class Game extends RSApplet {
 			plainFont = new TextDrawingArea(false, "p11_full", titleStreamLoader);
 			boldFont = new TextDrawingArea(false, "p12_full", titleStreamLoader);
 			chatTextDrawingArea = new TextDrawingArea(false, "b12_full", titleStreamLoader);
-			TextDrawingArea aTextDrawingArea_1273 = new TextDrawingArea(true, "q8_full", titleStreamLoader);
+                        TextDrawingArea smallFont = new TextDrawingArea(true, "q8_full", titleStreamLoader);
 			drawLogo();
 			loadTitleScreen();
 			//repackCacheIndex(1);
@@ -7297,7 +7297,7 @@ public class Game extends RSApplet {
 			Sounds.unpack(stream);
 			// }
 			drawLoadingText(95, "Unpacking interfaces");
-			TextDrawingArea aclass30_sub2_sub1_sub4s[] = {plainFont, boldFont, chatTextDrawingArea, aTextDrawingArea_1273};
+                        TextDrawingArea aclass30_sub2_sub1_sub4s[] = {plainFont, boldFont, chatTextDrawingArea, smallFont};
 			RSInterface.unpack(streamLoader_1, aclass30_sub2_sub1_sub4s, streamLoader_2);
 			drawLoadingText(100, "Preparing game engine");
 			for (int j6 = 0; j6 < 33; j6++) {
@@ -10171,7 +10171,7 @@ public class Game extends RSApplet {
 					queuePendingSpawn(k17 + 1, -1, 0, l20, j7, 0, plane, k4, l14 + 1);
                                 player.animationStartCycle = l14 + loopCycle;
                                 player.animationEndCycle = k17 + loopCycle;
-					player.aModel_1714 = model;
+                                        player.overlayModel = model;
 					int i23 = class46.sizeX;
 					int j23 = class46.sizeY;
 					if (i20 == 1 || i20 == 3) {

--- a/2006Scape Client/src/main/java/Model.java
+++ b/2006Scape Client/src/main/java/Model.java
@@ -1352,15 +1352,15 @@ public final class Model extends Animable {
 		}
 		int i4 = k1 * k - j2 * j >> 16;
 		int j4 = boundingRadius * j >> 16;
-		int k4 = i4 + j4 << 9;
-		if (k4 / i3 <= -DrawingArea.anInt1387) {
-			return;
-		}
-		int l4 = j4 + (super.modelHeight * k >> 16);
-		int i5 = i4 - l4 << 9;
-		if (i5 / i3 >= DrawingArea.anInt1387) {
-			return;
-		}
+                int k4 = i4 + j4 << 9;
+                if (k4 / i3 <= -DrawingArea.viewportHalfHeight) {
+                        return;
+                }
+                int l4 = j4 + (super.modelHeight * k >> 16);
+                int i5 = i4 - l4 << 9;
+                if (i5 / i3 >= DrawingArea.viewportHalfHeight) {
+                        return;
+                }
 		int j5 = l2 + (super.modelHeight * j >> 16);
 		boolean flag = false;
 		if (k2 - j5 <= 50) {

--- a/2006Scape Client/src/main/java/Player.java
+++ b/2006Scape Client/src/main/java/Player.java
@@ -36,12 +36,12 @@ public final class Player extends Entity {
 				model = new Model(aclass30_sub2_sub4_sub6_1s);
 			}
 		}
-		if (aModel_1714 != null) {
-			if (Game.loopCycle >= animationEndCycle) {
-				aModel_1714 = null;
-			}
-			if (Game.loopCycle >= animationStartCycle && Game.loopCycle < animationEndCycle) {
-				Model model_1 = aModel_1714;
+                if (overlayModel != null) {
+                        if (Game.loopCycle >= animationEndCycle) {
+                                overlayModel = null;
+                        }
+                        if (Game.loopCycle >= animationStartCycle && Game.loopCycle < animationEndCycle) {
+                                Model model_1 = overlayModel;
 				model_1.translate(animationBaseX - super.x, animationBaseHeight - animationBaseY, animationBaseZ - super.y);
 				if (super.turnDirection == 512) {
 					model_1.calculateNormals();
@@ -53,8 +53,8 @@ public final class Player extends Entity {
 				} else if (super.turnDirection == 1536) {
 					model_1.calculateNormals();
 				}
-				Model aclass30_sub2_sub4_sub6s[] = {model, model_1};
-				model = new Model(aclass30_sub2_sub4_sub6s);
+                                Model aclass30_sub2_sub4_sub6s[] = {model, model_1};
+                                model = new Model(aclass30_sub2_sub4_sub6s);
 				if (super.turnDirection == 512) {
 					model_1.calculateNormals();
 				} else if (super.turnDirection == 1024) {
@@ -364,7 +364,7 @@ public final class Player extends Entity {
         int animationBaseX;
         int animationBaseHeight;
         int animationBaseZ;
-	Model aModel_1714;
+        Model overlayModel;
 	public final int[] equipment;
         private long appearanceHash;
         int boundingBoxMinX;

--- a/2006Scape Client/src/main/java/ShapedTile.java
+++ b/2006Scape Client/src/main/java/ShapedTile.java
@@ -14,7 +14,7 @@ final class ShapedTile {
 		int i5 = c / 2;
 		int j5 = c / 4;
 		int k5 = c * 3 / 4;
-		int ai[] = anIntArrayArray696[j3];
+                int ai[] = shapeVertexIndices[j3];
 		int l5 = ai.length;
 		vertexX = new int[l5];
 		vertexZ = new int[l5];
@@ -143,7 +143,7 @@ final class ShapedTile {
 			ai2[k6] = j9;
 		}
 
-		int ai3[] = anIntArrayArray697[j3];
+                int ai3[] = shapeFaceTemplates[j3];
 		int j7 = ai3.length / 4;
 		faceVertexA = new int[j7];
 		faceVertexB = new int[j7];
@@ -234,10 +234,10 @@ final class ShapedTile {
         static final int[] cameraVertexX = new int[6];
         static final int[] cameraVertexY = new int[6];
         static final int[] cameraVertexZ = new int[6];
-	static final int[] anIntArray693 = {1, 0};
-	static final int[] anIntArray694 = {2, 1};
-	static final int[] anIntArray695 = {3, 3};
-	private static final int[][] anIntArrayArray696 = {{1, 3, 5, 7}, {1, 3, 5, 7}, {1, 3, 5, 7}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 2, 6}, {1, 3, 5, 7, 2, 8}, {1, 3, 5, 7, 2, 8}, {1, 3, 5, 7, 11, 12}, {1, 3, 5, 7, 11, 12}, {1, 3, 5, 7, 13, 14}};
-	private static final int[][] anIntArrayArray697 = {{0, 1, 2, 3, 0, 0, 1, 3}, {1, 1, 2, 3, 1, 0, 1, 3}, {0, 1, 2, 3, 1, 0, 1, 3}, {0, 0, 1, 2, 0, 0, 2, 4, 1, 0, 4, 3}, {0, 0, 1, 4, 0, 0, 4, 3, 1, 1, 2, 4}, {0, 0, 4, 3, 1, 0, 1, 2, 1, 0, 2, 4}, {0, 1, 2, 4, 1, 0, 1, 4, 1, 0, 4, 3}, {0, 4, 1, 2, 0, 4, 2, 5, 1, 0, 4, 5, 1, 0, 5, 3}, {0, 4, 1, 2, 0, 4, 2, 3, 0, 4, 3, 5, 1, 0, 4, 5}, {0, 0, 4, 5, 1, 4, 1, 2, 1, 4, 2, 3, 1, 4, 3, 5}, {0, 0, 1, 5, 0, 1, 4, 5, 0, 1, 2, 4, 1, 0, 5, 3, 1, 5, 4, 3, 1, 4, 2, 3}, {1, 0, 1, 5, 1, 1, 4, 5, 1, 1, 2, 4, 0, 0, 5, 3, 0, 5, 4, 3, 0, 4, 2, 3}, {1, 0, 5, 4, 1, 0, 1, 5, 0, 0, 4, 3, 0, 4, 5, 3, 0, 5, 2, 3, 0, 1, 2, 5}};
+        static final int[] faceOrderA = {1, 0};
+        static final int[] faceOrderB = {2, 1};
+        static final int[] faceOrderC = {3, 3};
+        private static final int[][] shapeVertexIndices = {{1, 3, 5, 7}, {1, 3, 5, 7}, {1, 3, 5, 7}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 6}, {1, 3, 5, 7, 2, 6}, {1, 3, 5, 7, 2, 8}, {1, 3, 5, 7, 2, 8}, {1, 3, 5, 7, 11, 12}, {1, 3, 5, 7, 11, 12}, {1, 3, 5, 7, 13, 14}};
+        private static final int[][] shapeFaceTemplates = {{0, 1, 2, 3, 0, 0, 1, 3}, {1, 1, 2, 3, 1, 0, 1, 3}, {0, 1, 2, 3, 1, 0, 1, 3}, {0, 0, 1, 2, 0, 0, 2, 4, 1, 0, 4, 3}, {0, 0, 1, 4, 0, 0, 4, 3, 1, 1, 2, 4}, {0, 0, 4, 3, 1, 0, 1, 2, 1, 0, 2, 4}, {0, 1, 2, 4, 1, 0, 1, 4, 1, 0, 4, 3}, {0, 4, 1, 2, 0, 4, 2, 5, 1, 0, 4, 5, 1, 0, 5, 3}, {0, 4, 1, 2, 0, 4, 2, 3, 0, 4, 3, 5, 1, 0, 4, 5}, {0, 0, 4, 5, 1, 4, 1, 2, 1, 4, 2, 3, 1, 4, 3, 5}, {0, 0, 1, 5, 0, 1, 4, 5, 0, 1, 2, 4, 1, 0, 5, 3, 1, 5, 4, 3, 1, 4, 2, 3}, {1, 0, 1, 5, 1, 1, 4, 5, 1, 1, 2, 4, 0, 0, 5, 3, 0, 5, 4, 3, 0, 4, 2, 3}, {1, 0, 5, 4, 1, 0, 1, 5, 0, 0, 4, 3, 0, 4, 5, 3, 0, 5, 2, 3, 0, 1, 2, 5}};
 
 }

--- a/2006Scape Client/src/main/java/SizeConstants.java
+++ b/2006Scape Client/src/main/java/SizeConstants.java
@@ -5,7 +5,7 @@
 
 final class SizeConstants {
 
-	public static final int[] anIntArray552 = {
+        public static final int[] permutationTable = {
 		6, 21, 25, 33, 254, 127, 183, 87, 216, 215, 
 		211, 48, 15, 195, 149, 233, 162, 102, 104, 179, 
 		222, 103, 224, 81, 152, 89, 45, 11, 197, 187, 

--- a/2006Scape Client/src/main/java/SystemMidiPlayer.java
+++ b/2006Scape Client/src/main/java/SystemMidiPlayer.java
@@ -13,17 +13,17 @@ import javax.sound.midi.ShortMessage;
 
 final class SystemMidiPlayer extends AbstractMidiController implements Receiver
 {
-    private static Receiver aReceiver1850 = null;
-    private static Sequencer aSequencer1851 = null;
+    private static Receiver midiReceiver = null;
+    private static Sequencer midiSequencer = null;
     
     final void playMidi(int i, byte[] is, int i_0_, boolean bool) {
-    	if (aSequencer1851 != null) {
+        if (midiSequencer != null) {
     		try {
     			Sequence sequence = MidiSystem.getSequence(new ByteArrayInputStream(is));
-    			aSequencer1851.setSequence(sequence);
-    			aSequencer1851.setLoopCount(!bool ? 0 : -1);
-    			applyVolumeFade(0, i, -1L);
-    			aSequencer1851.start();
+                        midiSequencer.setSequence(sequence);
+                        midiSequencer.setLoopCount(!bool ? 0 : -1);
+                        applyVolumeFade(0, i, -1L);
+                        midiSequencer.start();
     		} catch (Exception exception) {
     			/* empty */
     		}
@@ -31,8 +31,8 @@ final class SystemMidiPlayer extends AbstractMidiController implements Receiver
     }
     
     final void stopMidi() {
-		if (aSequencer1851 != null) {
-		    aSequencer1851.stop();
+                if (midiSequencer != null) {
+                    midiSequencer.stop();
 		    resetAllControllers(-1L);
 		}
     }
@@ -40,15 +40,15 @@ final class SystemMidiPlayer extends AbstractMidiController implements Receiver
     public final synchronized void send(MidiMessage midimessage, long l) {
     	byte[] is = midimessage.getMessage();
     	if (is.length < 3 || !handleControlChange(is[0], is[1], is[2], l))
-    		aReceiver1850.send(midimessage, l);
+                midiReceiver.send(midimessage, l);
     }
     
     SystemMidiPlayer() {
 		try {
-		    aReceiver1850 = MidiSystem.getReceiver();
-		    aSequencer1851 = MidiSystem.getSequencer(false);
-		    aSequencer1851.getTransmitter().setReceiver(this);
-		    aSequencer1851.open();
+                    midiReceiver = MidiSystem.getReceiver();
+                    midiSequencer = MidiSystem.getSequencer(false);
+                    midiSequencer.getTransmitter().setReceiver(this);
+                    midiSequencer.open();
 		    resetAllControllers(-1L);
 		} catch (Exception exception) {
                    Game.closeMidiSystem();
@@ -56,14 +56,14 @@ final class SystemMidiPlayer extends AbstractMidiController implements Receiver
     }
     
     final void shutdown() {
-    	if (aSequencer1851 != null) {
-    		aSequencer1851.close();
-    		aSequencer1851 = null;
-    	}
-    	if (aReceiver1850 != null) {
-    		aReceiver1850.close();
-    		aReceiver1850 = null;
-    	}
+        if (midiSequencer != null) {
+                midiSequencer.close();
+                midiSequencer = null;
+        }
+        if (midiReceiver != null) {
+                midiReceiver.close();
+                midiReceiver = null;
+        }
     }
     
     public final void close() {
@@ -71,14 +71,14 @@ final class SystemMidiPlayer extends AbstractMidiController implements Receiver
     }
     
     final void setVolume(int i) {
-		if (aSequencer1851 != null) {
-		    setMasterVolume(i, -1L);
+        if (midiSequencer != null) {
+                    setMasterVolume(i, -1L);
 		}
     }
     
     final synchronized void adjustVolume(int i, int i_2_) {
-    	if (aSequencer1851 != null) {
-    		applyVolumeFade(i_2_, i, -1L);
+        if (midiSequencer != null) {
+                applyVolumeFade(i_2_, i, -1L);
     	}
     }
     
@@ -86,7 +86,7 @@ final class SystemMidiPlayer extends AbstractMidiController implements Receiver
         try {
                 ShortMessage shortmessage = new ShortMessage();
                 shortmessage.setMessage(status, data1, data2);
-                aReceiver1850.send(shortmessage, timestamp);
+                midiReceiver.send(shortmessage, timestamp);
         } catch (InvalidMidiDataException invalidmididataexception) {
                 /* empty */
                 }

--- a/rename-history.md
+++ b/rename-history.md
@@ -496,7 +496,9 @@ This document lists variable or identifier renames found in the commit history.
 ## Class40 -> ShapedTile
 
 ## Class56_Sub1_Sub1 -> SystemMidiPlayer
- - method790 -> closeMidiSystem
+- method790 -> closeMidiSystem
+- aReceiver1850 -> midiReceiver
+- aSequencer1851 -> midiSequencer
 
 ## Class47 -> CullingCluster
 
@@ -879,8 +881,9 @@ This document lists variable or identifier renames found in the commit history.
  - anInt1708 -> animationEndCycle
  - anInt1709 -> animationBaseY
  - anInt1711 -> animationBaseX
- - anInt1712 -> animationBaseHeight
+- anInt1712 -> animationBaseHeight
 - anInt1713 -> animationBaseZ
+- aModel_1714 -> overlayModel
 - aBoolean1699 -> skipAnimations
 - anInt1719 -> boundingBoxMinX
 - anInt1720 -> boundingBoxMinY
@@ -941,7 +944,12 @@ This document lists variable or identifier renames found in the commit history.
  - anIntArray676 -> faceColorA
  - anIntArray677 -> faceColorB
  - anIntArray678 -> faceColorC
- - anIntArray682 -> faceTexture
+- anIntArray682 -> faceTexture
+- anIntArray693 -> faceOrderA
+- anIntArray694 -> faceOrderB
+- anIntArray695 -> faceOrderC
+- anIntArrayArray696 -> shapeVertexIndices
+- anIntArrayArray697 -> shapeFaceTemplates
 
 ## Varp
  - anInt702 -> varpCount
@@ -1005,6 +1013,7 @@ This document lists variable or identifier renames found in the commit history.
 - aByteArrayArray1247 -> objectMapData
 - aTextDrawingArea_1270 -> plainFont
 - aTextDrawingArea_1271 -> boldFont
+- aTextDrawingArea_1273 -> smallFont
 - unknownInt1289 -> unusedSlotIndex
 - unknownInt1290 -> unusedSettingValue
 - aByteArray347 -> queuedMidiData
@@ -1019,6 +1028,10 @@ This document lists variable or identifier renames found in the commit history.
 - minimapInt2 -> minimapRotationOffset
 - minimapInt3 -> minimapZoom
 - backVmidIP2_2 -> midSubscreenBuffer
+- anInt974 -> overheadTextCount
+
+## DrawingArea
+ - anInt1387 -> viewportHalfHeight
 
 ## EntityDef
  - anInt55 -> turn90CCWAnimation
@@ -1056,6 +1069,7 @@ This document lists variable or identifier renames found in the commit history.
  - anInt363 -> precedenceAnimating
 - anInt364 -> precedenceWalking
 - anInt365 -> replayMode
+- anInt367 -> animationCount
 
 ## NodeSub
  - anInt1305 -> subNodeCounter
@@ -1063,3 +1077,6 @@ This document lists variable or identifier renames found in the commit history.
 ## Entity
  - aBoolean1541 -> forcedAnimation
  - aBooleanArray1553 -> movementQueueFlags
+
+## SizeConstants
+ - anIntArray552 -> permutationTable


### PR DESCRIPTION
## Summary
- rename fields like aModel_1714 and anInt974 to clearer identifiers
- update ShapedTile geometry naming in rename-history
- document all new renames

## Testing
- `git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac`

------
https://chatgpt.com/codex/tasks/task_e_68757fe8e8e0832bb4f2fe5287e556c2