### PR TITLE
[BOT] refactor(rename): ObjectManager variables

### DIFF
--- a/2006Scape Client/src/main/java/ObjectManager.java
+++ b/2006Scape Client/src/main/java/ObjectManager.java
@@ -31,7 +31,7 @@ final class ObjectManager {
 		return l >> 19 & 0xff;
 	}
 
-	public final void buildLandscape(CollisionMap aclass11[], WorldController worldController) {
+        public final void buildLandscape(CollisionMap collisionMaps[], WorldController worldController) {
 		for (int j = 0; j < 4; j++) {
 			for (int k = 0; k < 104; k++) {
 				for (int i1 = 0; i1 < 104; i1++) {
@@ -41,7 +41,7 @@ final class ObjectManager {
 							k1--;
 						}
 						if (k1 >= 0) {
-							aclass11[k1].blockTile(i1, k);
+                                                        collisionMaps[k1].blockTile(i1, k);
 						}
 					}
 				}
@@ -410,7 +410,7 @@ final class ObjectManager {
 		return k;
 	}
 
-	public static void loadObjectModels(Stream stream, OnDemandFetcher class42_sub1) {
+    public static void loadObjectModels(Stream stream, OnDemandFetcher onDemandFetcher) {
 		label0 : {
 			int i = -1;
 			do {
@@ -419,8 +419,8 @@ final class ObjectManager {
 					break label0;
 				}
 				i += j;
-				ObjectDef class46 = ObjectDef.forID(i);
-				class46.requestModels(class42_sub1);
+				ObjectDef objectDefinition = ObjectDef.forID(i);
+                                objectDefinition.requestModels(onDemandFetcher);
 				do {
 					int k = stream.readUnsignedSmart();
 					if (k == 0) {
@@ -455,7 +455,7 @@ final class ObjectManager {
 		}
 	}
 
-	private void placeObject(int i, WorldController worldController, CollisionMap class11, int j, int k, int l, int i1, int j1) {
+    private void placeObject(int i, WorldController worldController, CollisionMap collisionMap, int j, int k, int l, int i1, int j1) {
 		if ((hideRoofs || lowMem) && (tileFlags[0][l][i] & 2) == 0) {
 			if ((tileFlags[k][l][i] & 0x10) != 0) {
 				return;
@@ -472,36 +472,36 @@ final class ObjectManager {
 		int i2 = tileHeights[k][l + 1][i + 1];
 		int j2 = tileHeights[k][l][i + 1];
 		int k2 = k1 + l1 + i2 + j2 >> 2;
-		ObjectDef class46 = ObjectDef.forID(i1);
+		ObjectDef objectDefinition = ObjectDef.forID(i1);
 		int l2 = l + (i << 7) + (i1 << 14) + 0x40000000;
-		if (!class46.interactive) {
+		if (!objectDefinition.interactive) {
 			l2 += 0x80000000;
 		}
 		byte byte0 = (byte) ((j1 << 6) + j);
 		if (j == 22) {
-			if (lowMem && !class46.interactive && !class46.occludes) {
+			if (lowMem && !objectDefinition.interactive && !objectDefinition.occludes) {
 				return;
 			}
-			Object obj;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj = class46.getModel(22, j1, k1, l1, i2, j2, -1);
+			Object tileDecoration;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				tileDecoration = objectDefinition.getModel(22, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj = new DynamicObject(i1, j1, 22, l1, i2, k1, j2, class46.animationId, true);
+				tileDecoration = new DynamicObject(i1, j1, 22, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                        worldController.addTileDecoration(k, k2, i, ((Animable) obj), byte0, l2, l);
-			if (class46.isSolid && class46.interactive && class11 != null) {
-				class11.blockTile(i, l);
+                        worldController.addTileDecoration(k, k2, i, ((Animable) tileDecoration), byte0, l2, l);
+			if (objectDefinition.isSolid && objectDefinition.interactive && collisionMap != null) {
+				collisionMap.blockTile(i, l);
 			}
 			return;
 		}
 		if (j == 10 || j == 11) {
-			Object obj1;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj1 = class46.getModel(10, j1, k1, l1, i2, j2, -1);
+			Object dynamicObject;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				dynamicObject = objectDefinition.getModel(10, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj1 = new DynamicObject(i1, j1, 10, l1, i2, k1, j2, class46.animationId, true);
+				dynamicObject = new DynamicObject(i1, j1, 10, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-			if (obj1 != null) {
+			if (dynamicObject != null) {
 				int i5 = 0;
 				if (j == 11) {
 					i5 += 256;
@@ -509,18 +509,18 @@ final class ObjectManager {
 				int j4;
 				int l4;
 				if (j1 == 1 || j1 == 3) {
-					j4 = class46.sizeY;
-					l4 = class46.sizeX;
+					j4 = objectDefinition.sizeY;
+					l4 = objectDefinition.sizeX;
 				} else {
-					j4 = class46.sizeX;
-					l4 = class46.sizeY;
+					j4 = objectDefinition.sizeX;
+					l4 = objectDefinition.sizeY;
 				}
-                        if (worldController.addGameObject(l2, byte0, k2, l4, ((Animable) obj1), j4, k, i5, i, l) && class46.clipped) {
+                        if (worldController.addGameObject(l2, byte0, k2, l4, ((Animable) dynamicObject), j4, k, i5, i, l) && objectDefinition.clipped) {
 					Model model;
-					if (obj1 instanceof Model) {
-						model = (Model) obj1;
+					if (dynamicObject instanceof Model) {
+						model = (Model) dynamicObject;
 					} else {
-						model = class46.getModel(10, j1, k1, l1, i2, j2, -1);
+						model = objectDefinition.getModel(10, j1, k1, l1, i2, j2, -1);
 					}
 					if (model != null) {
 						for (int j5 = 0; j5 <= j4; j5++) {
@@ -539,85 +539,85 @@ final class ObjectManager {
 					}
 				}
 			}
-			if (class46.isSolid && class11 != null) {
-				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addObject(objectDefinition.impenetrable, objectDefinition.sizeX, objectDefinition.sizeY, l, i, j1);
 			}
 			return;
 		}
 		if (j >= 12) {
-			Object obj2;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj2 = class46.getModel(j, j1, k1, l1, i2, j2, -1);
+			Object genericObject;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				genericObject = objectDefinition.getModel(j, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj2 = new DynamicObject(i1, j1, j, l1, i2, k1, j2, class46.animationId, true);
+				genericObject = new DynamicObject(i1, j1, j, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addGameObject(l2, byte0, k2, 1, ((Animable) obj2), 1, k, 0, i, l);
+                    worldController.addGameObject(l2, byte0, k2, 1, ((Animable) genericObject), 1, k, 0, i, l);
 			if (j >= 12 && j <= 17 && j != 13 && k > 0) {
 				renderFlags[k][l][i] |= 0x924;
 			}
-			if (class46.isSolid && class11 != null) {
-				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addObject(objectDefinition.impenetrable, objectDefinition.sizeX, objectDefinition.sizeY, l, i, j1);
 			}
 			return;
 		}
 		if (j == 0) {
-			Object obj3;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj3 = class46.getModel(0, j1, k1, l1, i2, j2, -1);
+			Object straightBoundary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				straightBoundary = objectDefinition.getModel(0, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj3 = new DynamicObject(i1, j1, 0, l1, i2, k1, j2, class46.animationId, true);
+				straightBoundary = new DynamicObject(i1, j1, 0, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addBoundaryObject(wallFlags[j1], ((Animable) obj3), l2, i, byte0, l, null, k2, 0, k);
+                    worldController.addBoundaryObject(wallFlags[j1], ((Animable) straightBoundary), l2, i, byte0, l, null, k2, 0, k);
 			if (j1 == 0) {
-				if (class46.clipped) {
+				if (objectDefinition.clipped) {
 					tileShadowing[k][l][i] = 50;
 					tileShadowing[k][l][i + 1] = 50;
 				}
-				if (class46.adjustToTerrain) {
+				if (objectDefinition.adjustToTerrain) {
 					renderFlags[k][l][i] |= 0x249;
 				}
 			} else if (j1 == 1) {
-				if (class46.clipped) {
+				if (objectDefinition.clipped) {
 					tileShadowing[k][l][i + 1] = 50;
 					tileShadowing[k][l + 1][i + 1] = 50;
 				}
-				if (class46.adjustToTerrain) {
+				if (objectDefinition.adjustToTerrain) {
 					renderFlags[k][l][i + 1] |= 0x492;
 				}
 			} else if (j1 == 2) {
-				if (class46.clipped) {
+				if (objectDefinition.clipped) {
 					tileShadowing[k][l + 1][i] = 50;
 					tileShadowing[k][l + 1][i + 1] = 50;
 				}
-				if (class46.adjustToTerrain) {
+				if (objectDefinition.adjustToTerrain) {
 					renderFlags[k][l + 1][i] |= 0x249;
 				}
 			} else if (j1 == 3) {
-				if (class46.clipped) {
+				if (objectDefinition.clipped) {
 					tileShadowing[k][l][i] = 50;
 					tileShadowing[k][l + 1][i] = 50;
 				}
-				if (class46.adjustToTerrain) {
+				if (objectDefinition.adjustToTerrain) {
 					renderFlags[k][l][i] |= 0x492;
 				}
 			}
-			if (class46.isSolid && class11 != null) {
-				class11.addWall(i, j1, l, j, class46.impenetrable);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addWall(i, j1, l, j, objectDefinition.impenetrable);
 			}
-                        if (class46.wallDecoOffset != 16) {
-                                worldController.updateWallDecorationPosition(i, class46.wallDecoOffset, l, k);
+                        if (objectDefinition.wallDecoOffset != 16) {
+                                worldController.updateWallDecorationPosition(i, objectDefinition.wallDecoOffset, l, k);
 			}
 			return;
 		}
 		if (j == 1) {
-			Object obj4;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj4 = class46.getModel(1, j1, k1, l1, i2, j2, -1);
+			Object cornerBoundary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				cornerBoundary = objectDefinition.getModel(1, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj4 = new DynamicObject(i1, j1, 1, l1, i2, k1, j2, class46.animationId, true);
+				cornerBoundary = new DynamicObject(i1, j1, 1, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addBoundaryObject(boundaryRotationMasks[j1], ((Animable) obj4), l2, i, byte0, l, null, k2, 0, k);
-			if (class46.clipped) {
+                    worldController.addBoundaryObject(boundaryRotationMasks[j1], ((Animable) cornerBoundary), l2, i, byte0, l, null, k2, 0, k);
+			if (objectDefinition.clipped) {
 				if (j1 == 0) {
 					tileShadowing[k][l][i + 1] = 50;
 				} else if (j1 == 1) {
@@ -628,24 +628,24 @@ final class ObjectManager {
 					tileShadowing[k][l][i] = 50;
 				}
 			}
-			if (class46.isSolid && class11 != null) {
-				class11.addWall(i, j1, l, j, class46.impenetrable);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addWall(i, j1, l, j, objectDefinition.impenetrable);
 			}
 			return;
 		}
 		if (j == 2) {
 			int i3 = j1 + 1 & 3;
-			Object obj11;
-			Object obj12;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj11 = class46.getModel(2, 4 + j1, k1, l1, i2, j2, -1);
-				obj12 = class46.getModel(2, i3, k1, l1, i2, j2, -1);
+			Object boundaryPrimary;
+			Object boundarySecondary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				boundaryPrimary = objectDefinition.getModel(2, 4 + j1, k1, l1, i2, j2, -1);
+				boundarySecondary = objectDefinition.getModel(2, i3, k1, l1, i2, j2, -1);
 			} else {
-				obj11 = new DynamicObject(i1, 4 + j1, 2, l1, i2, k1, j2, class46.animationId, true);
-				obj12 = new DynamicObject(i1, i3, 2, l1, i2, k1, j2, class46.animationId, true);
+				boundaryPrimary = new DynamicObject(i1, 4 + j1, 2, l1, i2, k1, j2, objectDefinition.animationId, true);
+				boundarySecondary = new DynamicObject(i1, i3, 2, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addBoundaryObject(wallFlags[j1], ((Animable) obj11), l2, i, byte0, l, ((Animable) obj12), k2, wallFlags[i3], k);
-			if (class46.adjustToTerrain) {
+                    worldController.addBoundaryObject(wallFlags[j1], ((Animable) boundaryPrimary), l2, i, byte0, l, ((Animable) boundarySecondary), k2, wallFlags[i3], k);
+			if (objectDefinition.adjustToTerrain) {
 				if (j1 == 0) {
 					renderFlags[k][l][i] |= 0x249;
 					renderFlags[k][l][i + 1] |= 0x492;
@@ -660,23 +660,23 @@ final class ObjectManager {
 					renderFlags[k][l][i] |= 0x249;
 				}
 			}
-			if (class46.isSolid && class11 != null) {
-				class11.addWall(i, j1, l, j, class46.impenetrable);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addWall(i, j1, l, j, objectDefinition.impenetrable);
 			}
-                        if (class46.wallDecoOffset != 16) {
-                                worldController.updateWallDecorationPosition(i, class46.wallDecoOffset, l, k);
+                        if (objectDefinition.wallDecoOffset != 16) {
+                                worldController.updateWallDecorationPosition(i, objectDefinition.wallDecoOffset, l, k);
 			}
 			return;
 		}
 		if (j == 3) {
-			Object obj5;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj5 = class46.getModel(3, j1, k1, l1, i2, j2, -1);
+			Object diagonalBoundary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				diagonalBoundary = objectDefinition.getModel(3, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj5 = new DynamicObject(i1, j1, 3, l1, i2, k1, j2, class46.animationId, true);
+				diagonalBoundary = new DynamicObject(i1, j1, 3, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addBoundaryObject(boundaryRotationMasks[j1], ((Animable) obj5), l2, i, byte0, l, null, k2, 0, k);
-			if (class46.clipped) {
+                    worldController.addBoundaryObject(boundaryRotationMasks[j1], ((Animable) diagonalBoundary), l2, i, byte0, l, null, k2, 0, k);
+			if (objectDefinition.clipped) {
 				if (j1 == 0) {
 					tileShadowing[k][l][i + 1] = 50;
 				} else if (j1 == 1) {
@@ -687,25 +687,25 @@ final class ObjectManager {
 					tileShadowing[k][l][i] = 50;
 				}
 			}
-			if (class46.isSolid && class11 != null) {
-				class11.addWall(i, j1, l, j, class46.impenetrable);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addWall(i, j1, l, j, objectDefinition.impenetrable);
 			}
 			return;
 		}
 		if (j == 9) {
-			Object obj6;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj6 = class46.getModel(j, j1, k1, l1, i2, j2, -1);
+			Object interactiveObject;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				interactiveObject = objectDefinition.getModel(j, j1, k1, l1, i2, j2, -1);
 			} else {
-				obj6 = new DynamicObject(i1, j1, j, l1, i2, k1, j2, class46.animationId, true);
+				interactiveObject = new DynamicObject(i1, j1, j, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addGameObject(l2, byte0, k2, 1, ((Animable) obj6), 1, k, 0, i, l);
-			if (class46.isSolid && class11 != null) {
-				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, l, i, j1);
+                    worldController.addGameObject(l2, byte0, k2, 1, ((Animable) interactiveObject), 1, k, 0, i, l);
+			if (objectDefinition.isSolid && collisionMap != null) {
+				collisionMap.addObject(objectDefinition.impenetrable, objectDefinition.sizeX, objectDefinition.sizeY, l, i, j1);
 			}
 			return;
 		}
-		if (class46.contouredGround) {
+		if (objectDefinition.contouredGround) {
 			if (j1 == 1) {
 				int j3 = j2;
 				j2 = i2;
@@ -728,13 +728,13 @@ final class ObjectManager {
 			}
 		}
 		if (j == 4) {
-			Object obj7;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj7 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
+			Object wallDecoration;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration = objectDefinition.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj7 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
+				wallDecoration = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(l2, i, j1 * 512, k, 0, k2, ((Animable) obj7), l, byte0, 0, wallFlags[j1]);
+                    worldController.addWallDecoration(l2, i, j1 * 512, k, 0, k2, ((Animable) wallDecoration), l, byte0, 0, wallFlags[j1]);
 			return;
 		}
 		if (j == 5) {
@@ -743,43 +743,43 @@ final class ObjectManager {
 			if (k4 > 0) {
 				i4 = ObjectDef.forID(k4 >> 14 & 0x7fff).wallDecoOffset;
 			}
-			Object obj13;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj13 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
+			Object wallDecorationOffset;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecorationOffset = objectDefinition.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj13 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
+				wallDecorationOffset = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(l2, i, j1 * 512, k, deltaX[j1] * i4, k2, ((Animable) obj13), l, byte0, deltaY[j1] * i4, wallFlags[j1]);
+                    worldController.addWallDecoration(l2, i, j1 * 512, k, deltaX[j1] * i4, k2, ((Animable) wallDecorationOffset), l, byte0, deltaY[j1] * i4, wallFlags[j1]);
 			return;
 		}
 		if (j == 6) {
-			Object obj8;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj8 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
+			Object wallDecoration2;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration2 = objectDefinition.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj8 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
+				wallDecoration2 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(l2, i, j1, k, 0, k2, ((Animable) obj8), l, byte0, 0, 256);
+                    worldController.addWallDecoration(l2, i, j1, k, 0, k2, ((Animable) wallDecoration2), l, byte0, 0, 256);
 			return;
 		}
 		if (j == 7) {
-			Object obj9;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj9 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
+			Object wallDecoration3;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration3 = objectDefinition.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj9 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
+				wallDecoration3 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(l2, i, j1, k, 0, k2, ((Animable) obj9), l, byte0, 0, 512);
+                    worldController.addWallDecoration(l2, i, j1, k, 0, k2, ((Animable) wallDecoration3), l, byte0, 0, 512);
 			return;
 		}
 		if (j == 8) {
-			Object obj10;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj10 = class46.getModel(4, 0, k1, l1, i2, j2, -1);
+			Object wallDecoration4;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration4 = objectDefinition.getModel(4, 0, k1, l1, i2, j2, -1);
 			} else {
-				obj10 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, class46.animationId, true);
+				wallDecoration4 = new DynamicObject(i1, 0, 4, l1, i2, k1, j2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(l2, i, j1, k, 0, k2, ((Animable) obj10), l, byte0, 0, 768);
+                    worldController.addWallDecoration(l2, i, j1, k, 0, k2, ((Animable) wallDecoration4), l, byte0, 0, 768);
 		}
 	}
 
@@ -814,21 +814,21 @@ final class ObjectManager {
 	}
 
 	public static boolean isObjectVisible(int i, int j) {
-		ObjectDef class46 = ObjectDef.forID(i);
+		ObjectDef objectDefinition = ObjectDef.forID(i);
 		if (j == 11) {
 			j = 10;
 		}
 		if (j >= 5 && j <= 8) {
 			j = 4;
 		}
-		return class46.isModelReady(j);
+		return objectDefinition.isModelReady(j);
 	}
 
-	public final void loadChunk(int i, int j, CollisionMap aclass11[], int l, int i1, byte abyte0[], int j1, int k1, int l1) {
+        public final void loadChunk(int i, int j, CollisionMap collisionMaps[], int l, int i1, byte abyte0[], int j1, int k1, int l1) {
 		for (int i2 = 0; i2 < 8; i2++) {
 			for (int j2 = 0; j2 < 8; j2++) {
 				if (l + i2 > 0 && l + i2 < 103 && l1 + j2 > 0 && l1 + j2 < 103) {
-					aclass11[k1].clippingFlags[l + i2][l1 + j2] &= 0xfeffffff;
+                                        collisionMaps[k1].clippingFlags[l + i2][l1 + j2] &= 0xfeffffff;
 				}
 			}
 
@@ -850,12 +850,12 @@ final class ObjectManager {
 
 	}
 
-	public final void loadRegion(byte abyte0[], int i, int j, int k, int l, CollisionMap aclass11[]) {
+        public final void loadRegion(byte abyte0[], int i, int j, int k, int l, CollisionMap collisionMaps[]) {
 		for (int i1 = 0; i1 < 4; i1++) {
 			for (int j1 = 0; j1 < 64; j1++) {
 				for (int k1 = 0; k1 < 64; k1++) {
 					if (j + j1 > 0 && j + j1 < 103 && i + k1 > 0 && i + k1 < 103) {
-						aclass11[i1].clippingFlags[j + j1][i + k1] &= 0xfeffffff;
+                                                collisionMaps[i1].clippingFlags[j + j1][i + k1] &= 0xfeffffff;
 					}
 				}
 
@@ -939,7 +939,7 @@ final class ObjectManager {
 		}
 	}
 
-	public final void loadObjectChunk(CollisionMap aclass11[], WorldController worldController, int i, int j, int k, int l, byte abyte0[], int i1, int j1, int k1) {
+        public final void loadObjectChunk(CollisionMap collisionMaps[], WorldController worldController, int i, int j, int k, int l, byte abyte0[], int i1, int j1, int k1) {
 		label0 : {
 			Stream stream = new Stream(abyte0);
 			int l1 = -1;
@@ -963,19 +963,19 @@ final class ObjectManager {
 					int l3 = k3 >> 2;
 					int i4 = k3 & 3;
 					if (j3 == i && i3 >= i1 && i3 < i1 + 8 && l2 >= k && l2 < k + 8) {
-						ObjectDef class46 = ObjectDef.forID(l1);
-						int j4 = j + TileRotation.rotateWidth(j1, class46.sizeY, i3 & 7, l2 & 7, class46.sizeX);
-						int k4 = k1 + TileRotation.rotateHeight(l2 & 7, class46.sizeY, j1, class46.sizeX, i3 & 7);
+						ObjectDef objectDefinition = ObjectDef.forID(l1);
+						int j4 = j + TileRotation.rotateWidth(j1, objectDefinition.sizeY, i3 & 7, l2 & 7, objectDefinition.sizeX);
+						int k4 = k1 + TileRotation.rotateHeight(l2 & 7, objectDefinition.sizeY, j1, objectDefinition.sizeX, i3 & 7);
 						if (j4 > 0 && k4 > 0 && j4 < 103 && k4 < 103) {
 							int l4 = j3;
 							if ((tileFlags[1][j4][k4] & 2) == 2) {
 								l4--;
 							}
-							CollisionMap class11 = null;
+							CollisionMap collisionMap = null;
 							if (l4 >= 0) {
-								class11 = aclass11[l4];
+                                                        collisionMap = collisionMaps[l4];
 							}
-							placeObject(k4, worldController, class11, l3, l, j4, l1, i4 + j1 & 3);
+							placeObject(k4, worldController, collisionMap, l3, l, j4, l1, i4 + j1 & 3);
 						}
 					}
 				} while (true);
@@ -1030,39 +1030,39 @@ final class ObjectManager {
 		return (i & 0xff80) + j;
 	}
 
-	public static void addObject(WorldController worldController, int i, int j, int k, int l, CollisionMap class11, int ai[][][], int i1, int j1, int k1) {
+	public static void addObject(WorldController worldController, int i, int j, int k, int l, CollisionMap collisionMap, int ai[][][], int i1, int j1, int k1) {
 		int l1 = ai[l][i1][j];
 		int i2 = ai[l][i1 + 1][j];
 		int j2 = ai[l][i1 + 1][j + 1];
 		int k2 = ai[l][i1][j + 1];
 		int l2 = l1 + i2 + j2 + k2 >> 2;
-		ObjectDef class46 = ObjectDef.forID(j1);
+		ObjectDef objectDefinition = ObjectDef.forID(j1);
 		int i3 = i1 + (j << 7) + (j1 << 14) + 0x40000000;
-		if (!class46.interactive) {
+		if (!objectDefinition.interactive) {
 			i3 += 0x80000000;
 		}
 		byte byte1 = (byte) ((i << 6) + k);
 		if (k == 22) {
-			Object obj;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj = class46.getModel(22, i, l1, i2, j2, k2, -1);
+			Object tileDecoration;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				tileDecoration = objectDefinition.getModel(22, i, l1, i2, j2, k2, -1);
 			} else {
-				obj = new DynamicObject(j1, i, 22, i2, j2, l1, k2, class46.animationId, true);
+				tileDecoration = new DynamicObject(j1, i, 22, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                        worldController.addTileDecoration(k1, l2, j, ((Animable) obj), byte1, i3, i1);
-			if (class46.isSolid && class46.interactive) {
-				class11.blockTile(j, i1);
+                        worldController.addTileDecoration(k1, l2, j, ((Animable) tileDecoration), byte1, i3, i1);
+			if (objectDefinition.isSolid && objectDefinition.interactive) {
+				collisionMap.blockTile(j, i1);
 			}
 			return;
 		}
 		if (k == 10 || k == 11) {
-			Object obj1;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj1 = class46.getModel(10, i, l1, i2, j2, k2, -1);
+			Object dynamicObject;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				dynamicObject = objectDefinition.getModel(10, i, l1, i2, j2, k2, -1);
 			} else {
-				obj1 = new DynamicObject(j1, i, 10, i2, j2, l1, k2, class46.animationId, true);
+				dynamicObject = new DynamicObject(j1, i, 10, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-			if (obj1 != null) {
+			if (dynamicObject != null) {
 				int j5 = 0;
 				if (k == 11) {
 					j5 += 256;
@@ -1070,102 +1070,102 @@ final class ObjectManager {
 				int k4;
 				int i5;
 				if (i == 1 || i == 3) {
-					k4 = class46.sizeY;
-					i5 = class46.sizeX;
+					k4 = objectDefinition.sizeY;
+					i5 = objectDefinition.sizeX;
 				} else {
-					k4 = class46.sizeX;
-					i5 = class46.sizeY;
+					k4 = objectDefinition.sizeX;
+					i5 = objectDefinition.sizeY;
 				}
-                           worldController.addGameObject(i3, byte1, l2, i5, ((Animable) obj1), k4, k1, j5, j, i1);
+                           worldController.addGameObject(i3, byte1, l2, i5, ((Animable) dynamicObject), k4, k1, j5, j, i1);
 			}
-			if (class46.isSolid) {
-				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
+			if (objectDefinition.isSolid) {
+				collisionMap.addObject(objectDefinition.impenetrable, objectDefinition.sizeX, objectDefinition.sizeY, i1, j, i);
 			}
 			return;
 		}
 		if (k >= 12) {
-			Object obj2;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj2 = class46.getModel(k, i, l1, i2, j2, k2, -1);
+			Object genericObject;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				genericObject = objectDefinition.getModel(k, i, l1, i2, j2, k2, -1);
 			} else {
-				obj2 = new DynamicObject(j1, i, k, i2, j2, l1, k2, class46.animationId, true);
+				genericObject = new DynamicObject(j1, i, k, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                   worldController.addGameObject(i3, byte1, l2, 1, ((Animable) obj2), 1, k1, 0, j, i1);
-			if (class46.isSolid) {
-				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
+                   worldController.addGameObject(i3, byte1, l2, 1, ((Animable) genericObject), 1, k1, 0, j, i1);
+			if (objectDefinition.isSolid) {
+				collisionMap.addObject(objectDefinition.impenetrable, objectDefinition.sizeX, objectDefinition.sizeY, i1, j, i);
 			}
 			return;
 		}
 		if (k == 0) {
-			Object obj3;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj3 = class46.getModel(0, i, l1, i2, j2, k2, -1);
+			Object straightBoundary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				straightBoundary = objectDefinition.getModel(0, i, l1, i2, j2, k2, -1);
 			} else {
-				obj3 = new DynamicObject(j1, i, 0, i2, j2, l1, k2, class46.animationId, true);
+				straightBoundary = new DynamicObject(j1, i, 0, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                        worldController.addBoundaryObject(wallFlags[i], ((Animable) obj3), i3, j, byte1, i1, null, l2, 0, k1);
-			if (class46.isSolid) {
-				class11.addWall(j, i, i1, k, class46.impenetrable);
+                        worldController.addBoundaryObject(wallFlags[i], ((Animable) straightBoundary), i3, j, byte1, i1, null, l2, 0, k1);
+			if (objectDefinition.isSolid) {
+				collisionMap.addWall(j, i, i1, k, objectDefinition.impenetrable);
 			}
 			return;
 		}
 		if (k == 1) {
-			Object obj4;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj4 = class46.getModel(1, i, l1, i2, j2, k2, -1);
+			Object cornerBoundary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				cornerBoundary = objectDefinition.getModel(1, i, l1, i2, j2, k2, -1);
 			} else {
-				obj4 = new DynamicObject(j1, i, 1, i2, j2, l1, k2, class46.animationId, true);
+				cornerBoundary = new DynamicObject(j1, i, 1, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                        worldController.addBoundaryObject(boundaryRotationMasks[i], ((Animable) obj4), i3, j, byte1, i1, null, l2, 0, k1);
-			if (class46.isSolid) {
-				class11.addWall(j, i, i1, k, class46.impenetrable);
+                        worldController.addBoundaryObject(boundaryRotationMasks[i], ((Animable) cornerBoundary), i3, j, byte1, i1, null, l2, 0, k1);
+			if (objectDefinition.isSolid) {
+				collisionMap.addWall(j, i, i1, k, objectDefinition.impenetrable);
 			}
 			return;
 		}
 		if (k == 2) {
 			int j3 = i + 1 & 3;
-			Object obj11;
-			Object obj12;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj11 = class46.getModel(2, 4 + i, l1, i2, j2, k2, -1);
-				obj12 = class46.getModel(2, j3, l1, i2, j2, k2, -1);
+			Object boundaryPrimary;
+			Object boundarySecondary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				boundaryPrimary = objectDefinition.getModel(2, 4 + i, l1, i2, j2, k2, -1);
+				boundarySecondary = objectDefinition.getModel(2, j3, l1, i2, j2, k2, -1);
 			} else {
-				obj11 = new DynamicObject(j1, 4 + i, 2, i2, j2, l1, k2, class46.animationId, true);
-				obj12 = new DynamicObject(j1, j3, 2, i2, j2, l1, k2, class46.animationId, true);
+				boundaryPrimary = new DynamicObject(j1, 4 + i, 2, i2, j2, l1, k2, objectDefinition.animationId, true);
+				boundarySecondary = new DynamicObject(j1, j3, 2, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                        worldController.addBoundaryObject(wallFlags[i], ((Animable) obj11), i3, j, byte1, i1, ((Animable) obj12), l2, wallFlags[j3], k1);
-			if (class46.isSolid) {
-				class11.addWall(j, i, i1, k, class46.impenetrable);
+                        worldController.addBoundaryObject(wallFlags[i], ((Animable) boundaryPrimary), i3, j, byte1, i1, ((Animable) boundarySecondary), l2, wallFlags[j3], k1);
+			if (objectDefinition.isSolid) {
+				collisionMap.addWall(j, i, i1, k, objectDefinition.impenetrable);
 			}
 			return;
 		}
 		if (k == 3) {
-			Object obj5;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj5 = class46.getModel(3, i, l1, i2, j2, k2, -1);
+			Object diagonalBoundary;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				diagonalBoundary = objectDefinition.getModel(3, i, l1, i2, j2, k2, -1);
 			} else {
-				obj5 = new DynamicObject(j1, i, 3, i2, j2, l1, k2, class46.animationId, true);
+				diagonalBoundary = new DynamicObject(j1, i, 3, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                        worldController.addBoundaryObject(boundaryRotationMasks[i], ((Animable) obj5), i3, j, byte1, i1, null, l2, 0, k1);
-			if (class46.isSolid) {
-				class11.addWall(j, i, i1, k, class46.impenetrable);
+                        worldController.addBoundaryObject(boundaryRotationMasks[i], ((Animable) diagonalBoundary), i3, j, byte1, i1, null, l2, 0, k1);
+			if (objectDefinition.isSolid) {
+				collisionMap.addWall(j, i, i1, k, objectDefinition.impenetrable);
 			}
 			return;
 		}
 		if (k == 9) {
-			Object obj6;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj6 = class46.getModel(k, i, l1, i2, j2, k2, -1);
+			Object interactiveObject;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				interactiveObject = objectDefinition.getModel(k, i, l1, i2, j2, k2, -1);
 			} else {
-				obj6 = new DynamicObject(j1, i, k, i2, j2, l1, k2, class46.animationId, true);
+				interactiveObject = new DynamicObject(j1, i, k, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                   worldController.addGameObject(i3, byte1, l2, 1, ((Animable) obj6), 1, k1, 0, j, i1);
-			if (class46.isSolid) {
-				class11.addObject(class46.impenetrable, class46.sizeX, class46.sizeY, i1, j, i);
+                   worldController.addGameObject(i3, byte1, l2, 1, ((Animable) interactiveObject), 1, k1, 0, j, i1);
+			if (objectDefinition.isSolid) {
+				collisionMap.addObject(objectDefinition.impenetrable, objectDefinition.sizeX, objectDefinition.sizeY, i1, j, i);
 			}
 			return;
 		}
-		if (class46.contouredGround) {
+		if (objectDefinition.contouredGround) {
 			if (i == 1) {
 				int k3 = k2;
 				k2 = j2;
@@ -1188,13 +1188,13 @@ final class ObjectManager {
 			}
 		}
 		if (k == 4) {
-			Object obj7;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj7 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
+			Object wallDecoration;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration = objectDefinition.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj7 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
+				wallDecoration = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(i3, j, i * 512, k1, 0, l2, ((Animable) obj7), i1, byte1, 0, wallFlags[i]);
+                    worldController.addWallDecoration(i3, j, i * 512, k1, 0, l2, ((Animable) wallDecoration), i1, byte1, 0, wallFlags[i]);
 			return;
 		}
 		if (k == 5) {
@@ -1203,43 +1203,43 @@ final class ObjectManager {
 			if (l4 > 0) {
 				j4 = ObjectDef.forID(l4 >> 14 & 0x7fff).wallDecoOffset;
 			}
-			Object obj13;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj13 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
+			Object wallDecorationOffset;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecorationOffset = objectDefinition.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj13 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
+				wallDecorationOffset = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(i3, j, i * 512, k1, deltaX[i] * j4, l2, ((Animable) obj13), i1, byte1, deltaY[i] * j4, wallFlags[i]);
+                    worldController.addWallDecoration(i3, j, i * 512, k1, deltaX[i] * j4, l2, ((Animable) wallDecorationOffset), i1, byte1, deltaY[i] * j4, wallFlags[i]);
 			return;
 		}
 		if (k == 6) {
-			Object obj8;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj8 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
+			Object wallDecoration2;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration2 = objectDefinition.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj8 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
+				wallDecoration2 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(i3, j, i, k1, 0, l2, ((Animable) obj8), i1, byte1, 0, 256);
+                    worldController.addWallDecoration(i3, j, i, k1, 0, l2, ((Animable) wallDecoration2), i1, byte1, 0, 256);
 			return;
 		}
 		if (k == 7) {
-			Object obj9;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj9 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
+			Object wallDecoration3;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration3 = objectDefinition.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj9 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
+				wallDecoration3 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(i3, j, i, k1, 0, l2, ((Animable) obj9), i1, byte1, 0, 512);
+                    worldController.addWallDecoration(i3, j, i, k1, 0, l2, ((Animable) wallDecoration3), i1, byte1, 0, 512);
 			return;
 		}
 		if (k == 8) {
-			Object obj10;
-			if (class46.animationId == -1 && class46.childrenIDs == null) {
-				obj10 = class46.getModel(4, 0, l1, i2, j2, k2, -1);
+			Object wallDecoration4;
+			if (objectDefinition.animationId == -1 && objectDefinition.childrenIDs == null) {
+				wallDecoration4 = objectDefinition.getModel(4, 0, l1, i2, j2, k2, -1);
 			} else {
-				obj10 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, class46.animationId, true);
+				wallDecoration4 = new DynamicObject(j1, 0, 4, i2, j2, l1, k2, objectDefinition.animationId, true);
 			}
-                    worldController.addWallDecoration(i3, j, i, k1, 0, l2, ((Animable) obj10), i1, byte1, 0, 768);
+                    worldController.addWallDecoration(i3, j, i, k1, 0, l2, ((Animable) wallDecoration4), i1, byte1, 0, 768);
 		}
 	}
 
@@ -1278,9 +1278,9 @@ final class ObjectManager {
 					int i_261_ = i_259_ + i;
 					int i_262_ = i_258_ + i_250_;
 					if (i_261_ > 0 && i_262_ > 0 && i_261_ < 103 && i_262_ < 103) {
-						ObjectDef class46 = ObjectDef.forID(i_252_);
-						if (i_260_ != 22 || !lowMem || class46.interactive || class46.occludes) {
-							bool &= class46.areModelsReady();
+						ObjectDef objectDefinition = ObjectDef.forID(i_252_);
+						if (i_260_ != 22 || !lowMem || objectDefinition.interactive || objectDefinition.occludes) {
+							bool &= objectDefinition.areModelsReady();
 							bool_255_ = true;
 						}
 					}
@@ -1290,7 +1290,7 @@ final class ObjectManager {
 		return bool;
 	}
 
-	public final void loadObjects(int i, CollisionMap aclass11[], int j, WorldController worldController, byte abyte0[]) {
+        public final void loadObjects(int i, CollisionMap collisionMaps[], int j, WorldController worldController, byte abyte0[]) {
 		label0 : {
 			Stream stream = new Stream(abyte0);
 			int l = -1;
@@ -1320,11 +1320,11 @@ final class ObjectManager {
 						if ((tileFlags[1][j3][k3] & 2) == 2) {
 							l3--;
 						}
-						CollisionMap class11 = null;
+						CollisionMap collisionMap = null;
 						if (l3 >= 0) {
-							class11 = aclass11[l3];
+                                                   collisionMap = collisionMaps[l3];
 						}
-						placeObject(k3, worldController, class11, l2, j2, j3, l, i3);
+						placeObject(k3, worldController, collisionMap, l2, j2, j3, l, i3);
 					}
 				} while (true);
 			} while (true);

--- a/rename-history.md
+++ b/rename-history.md
@@ -572,6 +572,24 @@ This document lists variable or identifier renames found in the commit history.
 - aByteArrayArrayArray148 -> tileOverlayOrientations
 - aByteArrayArrayArray134 -> tileShadowing
 - anIntArray140 -> boundaryRotationMasks
+- aclass11 -> collisionMaps
+- class11 -> collisionMap
+- class42_sub1 -> onDemandFetcher
+- class46 -> objectDefinition
+- obj -> tileDecoration
+- obj1 -> dynamicObject
+- obj2 -> genericObject
+- obj3 -> straightBoundary
+- obj4 -> cornerBoundary
+- obj5 -> diagonalBoundary
+- obj6 -> interactiveObject
+- obj7 -> wallDecoration
+- obj8 -> wallDecoration2
+- obj9 -> wallDecoration3
+- obj10 -> wallDecoration4
+- obj11 -> boundaryPrimary
+- obj12 -> boundarySecondary
+- obj13 -> wallDecorationOffset
 
 ## Censor
  - method509 -> applyWordFilter


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item | Status |
| --- | --- |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes | N/A |
| ≥ 80 % coverage on touched lines | N/A |
| Net Δ lines < 5 000 | ✅ |
| ≤ 10 files modified | ✅ |
| Branch rebased onto latest `main` | ✅ |
| PR labeled `bot` | ✅ |
| No new external dependencies | ✅ |

## 🔍 What & Why
Refactors `ObjectManager` by replacing obfuscated variable names with meaningful alternatives. This improves code readability and documents the changes in `rename-history.md` for future reference.

## 🗂️ Detailed Changes
- Renamed local variables such as `class46`, `class11`, and `obj1` to descriptive names.
- Updated method parameters from `aclass11` to `collisionMaps`.
- Recorded mappings in `rename-history.md`.

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| aclass11 | collisionMaps |
| class11 | collisionMap |
| class42_sub1 | onDemandFetcher |
| class46 | objectDefinition |
| obj | tileDecoration |
| obj1 | dynamicObject |
| obj2 | genericObject |
| obj3 | straightBoundary |
| obj4 | cornerBoundary |
| obj5 | diagonalBoundary |
| obj6 | interactiveObject |
| obj7 | wallDecoration |
| obj8 | wallDecoration2 |
| obj9 | wallDecoration3 |
| obj10 | wallDecoration4 |
| obj11 | boundaryPrimary |
| obj12 | boundarySecondary |
| obj13 | wallDecorationOffset |

- **Batch**: ObjectManager variables
- **Revert command**: `git revert -m 1 63b0b548`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/ObjectManager.java | 460 +++++++++++-----------
 rename-history.md                                 |  18 +
 2 files changed, 248 insertions(+), 230 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeds with warnings:
```
$ git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac
... (warnings omitted) ...
```

## 📝 Rollback Plan
If this PR causes failures on `main`, revert with the command above.

------
https://chatgpt.com/codex/tasks/task_e_6875f7781da0832b9b6a58184875eca5