### PR TITLE
[BOT] refactor(rename): aclass30_sub2_sub4_sub6s → tempModels

### DIFF
--- a/2006Scape Client/src/main/java/EntityDef.java
+++ b/2006Scape Client/src/main/java/EntityDef.java
@@ -53,17 +53,17 @@ public final class EntityDef {
 		if (flag1) {
 			return null;
 		}
-                Model aclass30_sub2_sub4_sub6s[] = new Model[headModelIds.length];
+                Model tempModels[] = new Model[headModelIds.length];
                 for (int j = 0; j < headModelIds.length; j++) {
-                        aclass30_sub2_sub4_sub6s[j] = Model.create(headModelIds[j]);
+                        tempModels[j] = Model.create(headModelIds[j]);
                 }
 
-		Model model;
-		if (aclass30_sub2_sub4_sub6s.length == 1) {
-			model = aclass30_sub2_sub4_sub6s[0];
-		} else {
-			model = new Model(aclass30_sub2_sub4_sub6s.length, aclass30_sub2_sub4_sub6s);
-		}
+                Model model;
+                if (tempModels.length == 1) {
+                        model = tempModels[0];
+                } else {
+                        model = new Model(tempModels.length, tempModels);
+                }
                 if (originalModelColors != null) {
                         for (int k = 0; k < originalModelColors.length; k++) {
                                 model.recolor(originalModelColors[k], modifiedModelColors[k]);
@@ -140,16 +140,16 @@ public final class EntityDef {
 			if (flag) {
 				return null;
 			}
-                        Model aclass30_sub2_sub4_sub6s[] = new Model[modelIds.length];
+                        Model tempModels[] = new Model[modelIds.length];
                         for (int j1 = 0; j1 < modelIds.length; j1++) {
-                                aclass30_sub2_sub4_sub6s[j1] = Model.create(modelIds[j1]);
-			}
+                                tempModels[j1] = Model.create(modelIds[j1]);
+                        }
 
-			if (aclass30_sub2_sub4_sub6s.length == 1) {
-				model = aclass30_sub2_sub4_sub6s[0];
-			} else {
-				model = new Model(aclass30_sub2_sub4_sub6s.length, aclass30_sub2_sub4_sub6s);
-			}
+                        if (tempModels.length == 1) {
+                                model = tempModels[0];
+                        } else {
+                                model = new Model(tempModels.length, tempModels);
+                        }
                         if (originalModelColors != null) {
                                 for (int k1 = 0; k1 < originalModelColors.length; k1++) {
                                         model.recolor(originalModelColors[k1], modifiedModelColors[k1]);

--- a/rename-history.md
+++ b/rename-history.md
@@ -1106,6 +1106,7 @@ This document lists variable or identifier renames found in the commit history.
  - aBoolean84 -> clickable
  - aBoolean87 -> minimapVisible
  - aBoolean93 -> priorityRender
+ - aclass30_sub2_sub4_sub6s -> tempModels
 ## Animation
  - anInt352 -> frameCount
  - anIntArray353 -> frameIds


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Rename obfuscated local array `aclass30_sub2_sub4_sub6s` in `EntityDef` to the clearer `tempModels`.

## 🗂️ Detailed Changes
- renamed all occurrences of `aclass30_sub2_sub4_sub6s` to `tempModels` in `EntityDef`
- recorded mapping in `rename-history.md`

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| aclass30_sub2_sub4_sub6s | tempModels |

- **Batch**: single
- **Revert command**: `git revert -m 1 e9bd7b48aeb54ff074ab77fb5e663ec9a5eeae13`

## 📊 Diff Stat
```text
 2006Scape Client/src/main/java/EntityDef.java | 32 +++++++++++++--------------
 rename-history.md                             |  1 +
 2 files changed, 17 insertions(+), 16 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded with warnings:
```
2006Scape Client/src/main/java/RSApplet.java:14: warning: [removal] Applet in java.applet has been deprecated and marked for removal
...
3 warnings
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of AGENTS.md applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_6875f9db6b48832b90a3e91e6b1cfaca