### PR TITLE
[BOT] refactor(rename): deobfuscate variable names

### DIFF
--- a/2006Scape Client/src/main/java/BZip2Decompressor.java
+++ b/2006Scape Client/src/main/java/BZip2Decompressor.java
@@ -25,18 +25,18 @@ final class BZip2Decompressor {
                 }
         }
 
-       private static void decompressBlock(BZip2State class32) {
-                byte byte4 = class32.stateOutCh;
-                int i = class32.stateOutLen;
-                int j = class32.nblockUsed;
-                int k = class32.k0;
+       private static void decompressBlock(BZip2State state) {
+                byte byte4 = state.stateOutCh;
+                int i = state.stateOutLen;
+                int j = state.nblockUsed;
+                int k = state.k0;
                 int ai[] = BZip2State.tt;
-                int l = class32.tPos;
-                byte abyte0[] = class32.output;
-                int i1 = class32.nextOut;
-                int j1 = class32.outRemaining;
+                int l = state.tPos;
+                byte abyte0[] = state.output;
+                int i1 = state.nextOut;
+                int j1 = state.outRemaining;
                 int k1 = j1;
-                int l1 = class32.saveNblock + 1;
+                int l1 = state.saveNblock + 1;
 		label0 : do {
 			if (i > 0) {
 				do {
@@ -126,94 +126,94 @@ final class BZip2Decompressor {
 				}
 			}
 		} while (true);
-                int i2 = class32.totalOutLo32;
-                class32.totalOutLo32 += k1 - j1;
-                if (class32.totalOutLo32 < i2) {
-                        class32.totalOutHi32++;
+                int i2 = state.totalOutLo32;
+                state.totalOutLo32 += k1 - j1;
+                if (state.totalOutLo32 < i2) {
+                        state.totalOutHi32++;
                 }
-                class32.stateOutCh = byte4;
-                class32.stateOutLen = i;
-                class32.nblockUsed = j;
-                class32.k0 = k;
+                state.stateOutCh = byte4;
+                state.stateOutLen = i;
+                state.nblockUsed = j;
+                state.k0 = k;
                 BZip2State.tt = ai;
-                class32.tPos = l;
-                class32.output = abyte0;
-                class32.nextOut = i1;
-                class32.outRemaining = j1;
+                state.tPos = l;
+                state.output = abyte0;
+                state.nextOut = i1;
+                state.outRemaining = j1;
 	}
 
-       private static void decompressStream(BZip2State class32) {
+       private static void decompressStream(BZip2State state) {
 		int k8 = 0;
 		int ai[] = null;
 		int ai1[] = null;
 		int ai2[] = null;
-                class32.blockSize100k = 1;
+                state.blockSize100k = 1;
                 if (BZip2State.tt == null) {
-                        BZip2State.tt = new int[class32.blockSize100k * 0x186a0];
+                        BZip2State.tt = new int[state.blockSize100k * 0x186a0];
 		}
 		boolean flag19 = true;
 		while (flag19) {
-			byte byte0 = readByte(class32);
+			byte byte0 = readByte(state);
 			if (byte0 == 23) {
 				return;
 			}
-                        byte0 = readByte(class32);
-                        byte0 = readByte(class32);
-                        byte0 = readByte(class32);
-                        byte0 = readByte(class32);
-                        byte0 = readByte(class32);
-                        class32.blockNo++;
-			byte0 = readByte(class32);
-			byte0 = readByte(class32);
-			byte0 = readByte(class32);
-			byte0 = readByte(class32);
-                        byte0 = readBit(class32);
-                        class32.blockRandomised = byte0 != 0;
-                        if (class32.blockRandomised) {
+                        byte0 = readByte(state);
+                        byte0 = readByte(state);
+                        byte0 = readByte(state);
+                        byte0 = readByte(state);
+                        byte0 = readByte(state);
+                        state.blockNo++;
+			byte0 = readByte(state);
+			byte0 = readByte(state);
+			byte0 = readByte(state);
+			byte0 = readByte(state);
+                        byte0 = readBit(state);
+                        state.blockRandomised = byte0 != 0;
+                        if (state.blockRandomised) {
 				System.out.println("PANIC! RANDOMISED BLOCK!");
 			}
-                        class32.origPtr = 0;
-                        byte0 = readByte(class32);
-                        class32.origPtr = class32.origPtr << 8 | byte0 & 0xff;
-                        byte0 = readByte(class32);
-                        class32.origPtr = class32.origPtr << 8 | byte0 & 0xff;
-                        byte0 = readByte(class32);
-                        class32.origPtr = class32.origPtr << 8 | byte0 & 0xff;
+                        state.origPtr = 0;
+                        byte0 = readByte(state);
+                        state.origPtr = state.origPtr << 8 | byte0 & 0xff;
+                        byte0 = readByte(state);
+                        state.origPtr = state.origPtr << 8 | byte0 & 0xff;
+                        byte0 = readByte(state);
+                        state.origPtr = state.origPtr << 8 | byte0 & 0xff;
                         for (int j = 0; j < 16; j++) {
-                                byte byte1 = readBit(class32);
-                                class32.inUse16[j] = byte1 == 1;
+                                byte byte1 = readBit(state);
+                                state.inUse16[j] = byte1 == 1;
                         }
 
                         for (int k = 0; k < 256; k++) {
-                                class32.inUse[k] = false;
+                                state.inUse[k] = false;
                         }
 
 			for (int l = 0; l < 16; l++) {
-                                if (class32.inUse16[l]) {
+                                if (state.inUse16[l]) {
 					for (int i3 = 0; i3 < 16; i3++) {
-						byte byte2 = readBit(class32);
+						byte byte2 = readBit(state);
                                                 if (byte2 == 1) {
-                                                        class32.inUse[l * 16 + i3] = true;
+                                                        state.inUse[l * 16 + i3] = true;
                                                 }
 					}
 
 				}
 			}
 
-                        makeMaps(class32);
-                        int i4 = class32.nInUse + 2;
-			int j4 = readBits(3, class32);
-			int k4 = readBits(15, class32);
+                        makeMaps(state);
+                        int i4 = state.nInUse + 2;
+			int j4 = readBits(3, state);
+			int k4 = readBits(15, state);
 			for (int i1 = 0; i1 < k4; i1++) {
 				int j3 = 0;
 				do {
-					byte byte3 = readBit(class32);
+					byte byte3 = readBit(state);
 					if (byte3 == 0) {
 						break;
 					}
 					j3++;
 				} while (true);
-                                class32.selectorMtf[i1] = (byte) j3;
+                                state.selectorMtf[i1] = (byte) j3;
 			}
 
 			byte abyte0[] = new byte[6];
@@ -222,32 +222,32 @@ final class BZip2Decompressor {
 			}
 
 			for (int j1 = 0; j1 < k4; j1++) {
-                                byte byte17 = class32.selectorMtf[j1];
+                                byte byte17 = state.selectorMtf[j1];
 				byte byte15 = abyte0[byte17];
 				for (; byte17 > 0; byte17--) {
 					abyte0[byte17] = abyte0[byte17 - 1];
 				}
 
                                 abyte0[0] = byte15;
-                                class32.selector[j1] = byte15;
+                                state.selector[j1] = byte15;
 			}
 
 			for (int k3 = 0; k3 < j4; k3++) {
-				int l6 = readBits(5, class32);
+				int l6 = readBits(5, state);
 				for (int k1 = 0; k1 < i4; k1++) {
 					do {
-						byte byte4 = readBit(class32);
+						byte byte4 = readBit(state);
 						if (byte4 == 0) {
 							break;
 						}
-						byte4 = readBit(class32);
+						byte4 = readBit(state);
 						if (byte4 == 0) {
 							l6++;
 						} else {
 							l6--;
 						}
 					} while (true);
-                                        class32.tempLen[k3][k1] = (byte) l6;
+                                        state.tempLen[k3][k1] = (byte) l6;
 				}
 
 			}
@@ -256,52 +256,52 @@ final class BZip2Decompressor {
 				byte byte8 = 32;
 				int i = 0;
 				for (int l1 = 0; l1 < i4; l1++) {
-                                        if (class32.tempLen[l3][l1] > i) {
-                                                i = class32.tempLen[l3][l1];
+                                        if (state.tempLen[l3][l1] > i) {
+                                                i = state.tempLen[l3][l1];
 					}
-                                        if (class32.tempLen[l3][l1] < byte8) {
-                                                byte8 = class32.tempLen[l3][l1];
+                                        if (state.tempLen[l3][l1] < byte8) {
+                                                byte8 = state.tempLen[l3][l1];
 					}
 				}
 
-                                createHuffmanTables(class32.limit[l3], class32.base[l3], class32.perm[l3], class32.tempLen[l3], byte8, i, i4);
-                                class32.minLens[l3] = byte8;
+                                createHuffmanTables(state.limit[l3], state.base[l3], state.perm[l3], state.tempLen[l3], byte8, i, i4);
+                                state.minLens[l3] = byte8;
 			}
 
-                        int l4 = class32.nInUse + 1;
+                        int l4 = state.nInUse + 1;
 			int i5 = -1;
 			int j5 = 0;
 			for (int i2 = 0; i2 <= 255; i2++) {
-                            class32.unzftab[i2] = 0;
+                            state.unzftab[i2] = 0;
 			}
 
 			int j9 = 4095;
 			for (int l8 = 15; l8 >= 0; l8--) {
 				for (int i9 = 15; i9 >= 0; i9--) {
-                                        class32.mtfa[j9] = (byte) (l8 * 16 + i9);
+                                        state.mtfa[j9] = (byte) (l8 * 16 + i9);
 					j9--;
 				}
 
-                                class32.mtfbase[l8] = j9 + 1;
+                                state.mtfbase[l8] = j9 + 1;
 			}
 
 			int i6 = 0;
 			if (j5 == 0) {
 				i5++;
 				j5 = 50;
-                                byte byte12 = class32.selector[i5];
-                                k8 = class32.minLens[byte12];
-                                ai = class32.limit[byte12];
-                                ai2 = class32.perm[byte12];
-                                ai1 = class32.base[byte12];
+                                byte byte12 = state.selector[i5];
+                                k8 = state.minLens[byte12];
+                                ai = state.limit[byte12];
+                                ai2 = state.perm[byte12];
+                                ai1 = state.base[byte12];
 			}
 			j5--;
 			int i7 = k8;
 			int l7;
 			byte byte9;
-			for (l7 = readBits(i7, class32); l7 > ai[i7]; l7 = l7 << 1 | byte9) {
+			for (l7 = readBits(i7, state); l7 > ai[i7]; l7 = l7 << 1 | byte9) {
 				i7++;
-				byte9 = readBit(class32);
+				byte9 = readBit(state);
 			}
 
 			for (int k5 = ai2[l7 - ai1[i7]]; k5 != l4;) {
@@ -318,26 +318,26 @@ final class BZip2Decompressor {
 						if (j5 == 0) {
 							i5++;
 							j5 = 50;
-                                                        byte byte13 = class32.selector[i5];
-                                                        k8 = class32.minLens[byte13];
-                                                        ai = class32.limit[byte13];
-                                                        ai2 = class32.perm[byte13];
-                                                        ai1 = class32.base[byte13];
+                                                        byte byte13 = state.selector[i5];
+                                                        k8 = state.minLens[byte13];
+                                                        ai = state.limit[byte13];
+                                                        ai2 = state.perm[byte13];
+                                                        ai1 = state.base[byte13];
 						}
 						j5--;
 						int j7 = k8;
 						int i8;
 						byte byte10;
-						for (i8 = readBits(j7, class32); i8 > ai[j7]; i8 = i8 << 1 | byte10) {
+						for (i8 = readBits(j7, state); i8 > ai[j7]; i8 = i8 << 1 | byte10) {
 							j7++;
-							byte10 = readBit(class32);
+							byte10 = readBit(state);
 						}
 
 						k5 = ai2[i8 - ai1[j7]];
 					} while (k5 == 0 || k5 == 1);
 					j6++;
-                                        byte byte5 = class32.seqToUnseq[class32.mtfa[class32.mtfbase[0]] & 0xff];
-                                    class32.unzftab[byte5 & 0xff] += j6;
+                                        byte byte5 = state.seqToUnseq[state.mtfa[state.mtfbase[0]] & 0xff];
+                                    state.unzftab[byte5 & 0xff] += j6;
 					for (; j6 > 0; j6--) {
                                                 BZip2State.tt[i6] = byte5 & 0xff;
 						i6++;
@@ -347,140 +347,140 @@ final class BZip2Decompressor {
 					int j11 = k5 - 1;
 					byte byte6;
 					if (j11 < 16) {
-                                                int j10 = class32.mtfbase[0];
-                                                byte6 = class32.mtfa[j10 + j11];
+                                                int j10 = state.mtfbase[0];
+                                                byte6 = state.mtfa[j10 + j11];
 						for (; j11 > 3; j11 -= 4) {
 							int k11 = j10 + j11;
-                                                        class32.mtfa[k11] = class32.mtfa[k11 - 1];
-                                                        class32.mtfa[k11 - 1] = class32.mtfa[k11 - 2];
-                                                        class32.mtfa[k11 - 2] = class32.mtfa[k11 - 3];
-                                                        class32.mtfa[k11 - 3] = class32.mtfa[k11 - 4];
+                                                        state.mtfa[k11] = state.mtfa[k11 - 1];
+                                                        state.mtfa[k11 - 1] = state.mtfa[k11 - 2];
+                                                        state.mtfa[k11 - 2] = state.mtfa[k11 - 3];
+                                                        state.mtfa[k11 - 3] = state.mtfa[k11 - 4];
 						}
 
 						for (; j11 > 0; j11--) {
-                                                        class32.mtfa[j10 + j11] = class32.mtfa[j10 + j11 - 1];
+                                                        state.mtfa[j10 + j11] = state.mtfa[j10 + j11 - 1];
 						}
 
-                                                class32.mtfa[j10] = byte6;
+                                                state.mtfa[j10] = byte6;
 					} else {
 						int l10 = j11 / 16;
 						int i11 = j11 % 16;
-                                                int k10 = class32.mtfbase[l10] + i11;
-                                                byte6 = class32.mtfa[k10];
-                                                for (; k10 > class32.mtfbase[l10]; k10--) {
-                                                        class32.mtfa[k10] = class32.mtfa[k10 - 1];
+                                                int k10 = state.mtfbase[l10] + i11;
+                                                byte6 = state.mtfa[k10];
+                                                for (; k10 > state.mtfbase[l10]; k10--) {
+                                                        state.mtfa[k10] = state.mtfa[k10 - 1];
 						}
 
-                                                class32.mtfbase[l10]++;
+                                                state.mtfbase[l10]++;
                                                 for (; l10 > 0; l10--) {
-                                                        class32.mtfbase[l10]--;
-                                                        class32.mtfa[class32.mtfbase[l10]] = class32.mtfa[class32.mtfbase[l10 - 1] + 16 - 1];
+                                                        state.mtfbase[l10]--;
+                                                        state.mtfa[state.mtfbase[l10]] = state.mtfa[state.mtfbase[l10 - 1] + 16 - 1];
                                                 }
 
-                                                class32.mtfbase[0]--;
-                                                class32.mtfa[class32.mtfbase[0]] = byte6;
-                                                if (class32.mtfbase[0] == 0) {
+                                                state.mtfbase[0]--;
+                                                state.mtfa[state.mtfbase[0]] = byte6;
+                                                if (state.mtfbase[0] == 0) {
 							int i10 = 4095;
 							for (int k9 = 15; k9 >= 0; k9--) {
 								for (int l9 = 15; l9 >= 0; l9--) {
-                                                                        class32.mtfa[i10] = class32.mtfa[class32.mtfbase[k9] + l9];
+                                                                        state.mtfa[i10] = state.mtfa[state.mtfbase[k9] + l9];
 									i10--;
 								}
 
-                                                                class32.mtfbase[k9] = i10 + 1;
+                                                                state.mtfbase[k9] = i10 + 1;
 							}
 
 						}
 					}
-                                    class32.unzftab[class32.seqToUnseq[byte6 & 0xff] & 0xff]++;
-                                        BZip2State.tt[i6] = class32.seqToUnseq[byte6 & 0xff] & 0xff;
+                                    state.unzftab[state.seqToUnseq[byte6 & 0xff] & 0xff]++;
+                                        BZip2State.tt[i6] = state.seqToUnseq[byte6 & 0xff] & 0xff;
 					i6++;
 					if (j5 == 0) {
 						i5++;
 						j5 = 50;
-                                                byte byte14 = class32.selector[i5];
-                                                k8 = class32.minLens[byte14];
-                                                ai = class32.limit[byte14];
-                                                ai2 = class32.perm[byte14];
-                                                ai1 = class32.base[byte14];
+                                                byte byte14 = state.selector[i5];
+                                                k8 = state.minLens[byte14];
+                                                ai = state.limit[byte14];
+                                                ai2 = state.perm[byte14];
+                                                ai1 = state.base[byte14];
 					}
 					j5--;
 					int k7 = k8;
 					int j8;
 					byte byte11;
-					for (j8 = readBits(k7, class32); j8 > ai[k7]; j8 = j8 << 1 | byte11) {
+					for (j8 = readBits(k7, state); j8 > ai[k7]; j8 = j8 << 1 | byte11) {
 						k7++;
-						byte11 = readBit(class32);
+						byte11 = readBit(state);
 					}
 
 					k5 = ai2[j8 - ai1[k7]];
 				}
 			}
 
-                        class32.stateOutLen = 0;
-                        class32.stateOutCh = 0;
-                        class32.cftab[0] = 0;
+                        state.stateOutLen = 0;
+                        state.stateOutCh = 0;
+                        state.cftab[0] = 0;
 			for (int j2 = 1; j2 <= 256; j2++) {
-                            class32.cftab[j2] = class32.unzftab[j2 - 1];
+                            state.cftab[j2] = state.unzftab[j2 - 1];
 			}
 
                         for (int k2 = 1; k2 <= 256; k2++) {
-                                class32.cftab[k2] += class32.cftab[k2 - 1];
+                                state.cftab[k2] += state.cftab[k2 - 1];
                         }
 
 			for (int l2 = 0; l2 < i6; l2++) {
                                 byte byte7 = (byte) (BZip2State.tt[l2] & 0xff);
-                                BZip2State.tt[class32.cftab[byte7 & 0xff]] |= l2 << 8;
-                                class32.cftab[byte7 & 0xff]++;
+                                BZip2State.tt[state.cftab[byte7 & 0xff]] |= l2 << 8;
+                                state.cftab[byte7 & 0xff]++;
 			}
 
-                        class32.tPos = BZip2State.tt[class32.origPtr] >> 8;
-                        class32.nblockUsed = 0;
-                        class32.tPos = BZip2State.tt[class32.tPos];
-                        class32.k0 = (byte) (class32.tPos & 0xff);
-                        class32.tPos >>= 8;
-                        class32.nblockUsed++;
-                        class32.saveNblock = i6;
-                        decompressBlock(class32);
-                        flag19 = class32.nblockUsed == class32.saveNblock + 1 && class32.stateOutLen == 0;
+                        state.tPos = BZip2State.tt[state.origPtr] >> 8;
+                        state.nblockUsed = 0;
+                        state.tPos = BZip2State.tt[state.tPos];
+                        state.k0 = (byte) (state.tPos & 0xff);
+                        state.tPos >>= 8;
+                        state.nblockUsed++;
+                        state.saveNblock = i6;
+                        decompressBlock(state);
+                        flag19 = state.nblockUsed == state.saveNblock + 1 && state.stateOutLen == 0;
 		}
 	}
 
-	private static byte readByte(BZip2State class32) {
-		return (byte) readBits(8, class32);
+	private static byte readByte(BZip2State state) {
+		return (byte) readBits(8, state);
 	}
 
-	private static byte readBit(BZip2State class32) {
-		return (byte) readBits(1, class32);
+	private static byte readBit(BZip2State state) {
+		return (byte) readBits(1, state);
 	}
 
-	private static int readBits(int i, BZip2State class32) {
+	private static int readBits(int i, BZip2State state) {
 		int j;
 		do {
-                        if (class32.bsLive >= i) {
-                                int k = class32.bsBuff >> class32.bsLive - i & (1 << i) - 1;
-                                class32.bsLive -= i;
+                        if (state.bsLive >= i) {
+                                int k = state.bsBuff >> state.bsLive - i & (1 << i) - 1;
+                                state.bsLive -= i;
 				j = k;
 				break;
 			}
-                        class32.bsBuff = class32.bsBuff << 8 | class32.input[class32.nextIn] & 0xff;
-                        class32.bsLive += 8;
-                        class32.nextIn++;
-                        class32.availIn--;
-                        class32.totalInLo32++;
-                        if (class32.totalInLo32 == 0) {
-                                class32.totalInHi32++;
+                        state.bsBuff = state.bsBuff << 8 | state.input[state.nextIn] & 0xff;
+                        state.bsLive += 8;
+                        state.nextIn++;
+                        state.availIn--;
+                        state.totalInLo32++;
+                        if (state.totalInLo32 == 0) {
+                                state.totalInHi32++;
                         }
                 } while (true);
 		return j;
 	}
 
-        private static void makeMaps(BZip2State class32) {
-                class32.nInUse = 0;
+        private static void makeMaps(BZip2State state) {
+                state.nInUse = 0;
                 for (int i = 0; i < 256; i++) {
-                        if (class32.inUse[i]) {
-                                class32.seqToUnseq[class32.nInUse] = (byte) i;
-                                class32.nInUse++;
+                        if (state.inUse[i]) {
+                                state.seqToUnseq[state.nInUse] = (byte) i;
+                                state.nInUse++;
                         }
                 }
 

--- a/2006Scape Client/src/main/java/DynamicObject.java
+++ b/2006Scape Client/src/main/java/DynamicObject.java
@@ -30,17 +30,17 @@ final class DynamicObject extends Animable {
 				j = animation.frameIds[currentFrame];
 			}
 		}
-		ObjectDef class46;
-		if (childIDs != null) {
-			class46 = getChildDefinition();
-		} else {
-			class46 = ObjectDef.forID(id);
-		}
-		if (class46 == null) {
-			return null;
-		} else {
-			return class46.getModel(type, orientation, tileHeight, tileHeight1, tileHeight2, tileHeight3, j);
-		}
+                ObjectDef objectDef;
+                if (childIDs != null) {
+                        objectDef = getChildDefinition();
+                } else {
+                        objectDef = ObjectDef.forID(id);
+                }
+                if (objectDef == null) {
+                        return null;
+                } else {
+                        return objectDef.getModel(type, orientation, tileHeight, tileHeight1, tileHeight2, tileHeight3, j);
+                }
 	}
 
 	private ObjectDef getChildDefinition() {
@@ -79,10 +79,10 @@ final class DynamicObject extends Animable {
                                 cycleStart -= (int) (Math.random() * animation.getFrameDelay(currentFrame));
 			}
 		}
-		ObjectDef class46 = ObjectDef.forID(id);
-                varbitId = class46.varbitId;
-                varpId = class46.varpId;
-		childIDs = class46.childrenIDs;
+                ObjectDef objectDef = ObjectDef.forID(id);
+                varbitId = objectDef.varbitId;
+                varpId = objectDef.varpId;
+                childIDs = objectDef.childrenIDs;
 	}
 
 	private int currentFrame;

--- a/2006Scape Client/src/main/java/SoundFilter.java
+++ b/2006Scape Client/src/main/java/SoundFilter.java
@@ -66,7 +66,7 @@ final class SoundFilter {
                 return filterPairs[channel] * 2;
         }
 
-	public void decode(Stream stream, SoundEnvelope class29) {
+	public void decode(Stream stream, SoundEnvelope envelope) {
 		int i = stream.readUnsignedByte();
 		filterPairs[0] = i >> 4;
 		filterPairs[1] = i & 0xf;
@@ -96,7 +96,7 @@ final class SoundFilter {
 			}
 
 			if (j != 0 || range[1] != range[0]) {
-				class29.decodeSegments(stream);
+				envelope.decodeSegments(stream);
 			}
 		} else {
 			range[0] = range[1] = 0;

--- a/2006Scape Client/src/main/java/WorldController.java
+++ b/2006Scape Client/src/main/java/WorldController.java
@@ -120,25 +120,25 @@ final class WorldController {
 
         public void addTile(int i, int j, int k, int l, int i1, int j1, int k1, int l1, int i2, int j2, int k2, int l2, int i3, int j3, int k3, int l3, int i4, int j4, int k4, int l4) {
 		if (l == 0) {
-                    PlainTile class43 = new PlainTile(k2, l2, i3, j3, -1, k4, false);
+                    PlainTile tile = new PlainTile(k2, l2, i3, j3, -1, k4, false);
 			for (int i5 = i; i5 >= 0; i5--) {
 				if (groundArray[i5][j][k] == null) {
 					groundArray[i5][j][k] = new Ground(i5, j, k);
 				}
 			}
 
-                        groundArray[i][j][k].plainTile = class43;
+                        groundArray[i][j][k].plainTile = tile;
 			return;
 		}
 		if (l == 1) {
-                    PlainTile class43_1 = new PlainTile(k3, l3, i4, j4, j1, l4, k1 == l1 && k1 == i2 && k1 == j2);
+                    PlainTile alternateTile = new PlainTile(k3, l3, i4, j4, j1, l4, k1 == l1 && k1 == i2 && k1 == j2);
 			for (int j5 = i; j5 >= 0; j5--) {
 				if (groundArray[j5][j][k] == null) {
 					groundArray[j5][j][k] = new Ground(j5, j, k);
 				}
 			}
 
-                        groundArray[i][j][k].plainTile = class43_1;
+                        groundArray[i][j][k].plainTile = alternateTile;
 			return;
 		}
                 ShapedTile shapedTile = new ShapedTile(k, k3, j3, i2, j1, i4, i1, k2, k4, i3, j2, l1, k1, l, j4, l3, l2, j, l4);
@@ -676,9 +676,9 @@ final class WorldController {
 		int ai[] = model_1.vertexX;
             int i1 = model_1.vertexCount;
             for (int j1 = 0; j1 < model.vertexCount; j1++) {
-			VertexNormal class33 = model.vertexNormals[j1];
-			VertexNormal class33_1 = model.vertexNormalTemp[j1];
-			if (class33_1.magnitude != 0) {
+			VertexNormal normal = model.vertexNormals[j1];
+			VertexNormal tempNormal = model.vertexNormalTemp[j1];
+			if (tempNormal.magnitude != 0) {
 				int i2 = model.vertexY[j1] - j;
 				if (i2 <= model_1.maxY) {
 					int j2 = model.vertexX[j1] - i;
@@ -686,17 +686,17 @@ final class WorldController {
 						int k2 = model.vertexZ[j1] - k;
 						if (k2 >= model_1.minZ && k2 <= model_1.maxZ) {
 							for (int l2 = 0; l2 < i1; l2++) {
-								VertexNormal class33_2 = model_1.vertexNormals[l2];
-								VertexNormal class33_3 = model_1.vertexNormalTemp[l2];
-								if (j2 == ai[l2] && k2 == model_1.vertexZ[l2] && i2 == model_1.vertexY[l2] && class33_3.magnitude != 0) {
-									class33.x += class33_3.x;
-									class33.y += class33_3.y;
-									class33.z += class33_3.z;
-									class33.magnitude += class33_3.magnitude;
-									class33_2.x += class33_1.x;
-									class33_2.y += class33_1.y;
-									class33_2.z += class33_1.z;
-									class33_2.magnitude += class33_1.magnitude;
+								VertexNormal otherNormal = model_1.vertexNormals[l2];
+								VertexNormal otherTempNormal = model_1.vertexNormalTemp[l2];
+								if (j2 == ai[l2] && k2 == model_1.vertexZ[l2] && i2 == model_1.vertexY[l2] && otherTempNormal.magnitude != 0) {
+									normal.x += otherTempNormal.x;
+									normal.y += otherTempNormal.y;
+									normal.z += otherTempNormal.z;
+									normal.magnitude += otherTempNormal.magnitude;
+									otherNormal.x += tempNormal.x;
+									otherNormal.y += tempNormal.y;
+									otherNormal.z += tempNormal.z;
+									otherNormal.magnitude += tempNormal.magnitude;
 									l++;
 									vertexVisitA[j1] = mergeCycleId;
 									vertexVisitB[l2] = mergeCycleId;
@@ -732,9 +732,9 @@ final class WorldController {
 		if (groundTile == null) {
 			return;
 		}
-                PlainTile class43 = groundTile.plainTile;
-                if (class43 != null) {
-                        int j1 = class43.orientation;
+                PlainTile tile = groundTile.plainTile;
+                if (tile != null) {
+                        int j1 = tile.orientation;
 			if (j1 == 0) {
 				return;
 			}
@@ -1276,12 +1276,12 @@ final class WorldController {
 					currentTile.needsProcessing = false;
 					int l1 = 0;
 					label0 : for (int k2 = 0; k2 < i1; k2++) {
-                                                SceneObject class28_1 = currentTile.obj5Array[k2];
-                                                if (class28_1.lastDrawn == renderCycle) {
+                                                SceneObject objTile = currentTile.obj5Array[k2];
+                                                if (objTile.lastDrawn == renderCycle) {
                                                         continue;
                                                 }
-                                                for (int k3 = class28_1.startX; k3 <= class28_1.endX; k3++) {
-                                                        for (int l4 = class28_1.startY; l4 <= class28_1.endY; l4++) {
+                                                for (int k3 = objTile.startX; k3 <= objTile.endX; k3++) {
+                                                        for (int l4 = objTile.startY; l4 <= objTile.endY; l4++) {
                                                                 Ground cullCheckTile = planeTiles[k3][l4];
                                                                 if (cullCheckTile.tileActive) {
                                                                         currentTile.needsProcessing = true;
@@ -1290,16 +1290,16 @@ final class WorldController {
 										continue;
 									}
                                                                         int l6 = 0;
-                                                                        if (k3 > class28_1.startX) {
+                                                                        if (k3 > objTile.startX) {
                                                                                 l6++;
                                                                         }
-                                                                        if (k3 < class28_1.endX) {
+                                                                        if (k3 < objTile.endX) {
                                                                                 l6 += 4;
                                                                         }
-                                                                        if (l4 > class28_1.startY) {
+                                                                        if (l4 > objTile.startY) {
                                                                                 l6 += 8;
                                                                         }
-                                                                        if (l4 < class28_1.endY) {
+                                                                        if (l4 < objTile.endY) {
                                                                                 l6 += 2;
                                                                         }
                                                                         if ((l6 & cullCheckTile.cullFlags) != currentTile.cullOpposite) {
@@ -1312,18 +1312,18 @@ final class WorldController {
 
 						}
 
-                                                sceneObjectBuffer[l1++] = class28_1;
-                                                int i5 = cameraTileX - class28_1.startX;
-                                                int i6 = class28_1.endX - cameraTileX;
+                                                sceneObjectBuffer[l1++] = objTile;
+                                                int i5 = cameraTileX - objTile.startX;
+                                                int i6 = objTile.endX - cameraTileX;
 						if (i6 > i5) {
 							i5 = i6;
 						}
-                                                int i7 = cameraTileY - class28_1.startY;
-                                                int j8 = class28_1.endY - cameraTileY;
+                                                int i7 = cameraTileY - objTile.startY;
+                                                int j8 = objTile.endY - cameraTileY;
                                                 if (j8 > i7) {
-                                                        class28_1.distanceFromCamera = i5 + j8;
+                                                        objTile.distanceFromCamera = i5 + j8;
                                                 } else {
-                                                        class28_1.distanceFromCamera = i5 + i7;
+                                                        objTile.distanceFromCamera = i5 + i7;
                                                 }
                                         }
 
@@ -1331,14 +1331,14 @@ final class WorldController {
 						int i3 = -50;
 						int l3 = -1;
 						for (int j5 = 0; j5 < l1; j5++) {
-                                                        SceneObject class28_2 = sceneObjectBuffer[j5];
-                                                        if (class28_2.lastDrawn != renderCycle) {
-                                                                if (class28_2.distanceFromCamera > i3) {
-                                                                        i3 = class28_2.distanceFromCamera;
+                                                        SceneObject queuedObj = sceneObjectBuffer[j5];
+                                                        if (queuedObj.lastDrawn != renderCycle) {
+                                                                if (queuedObj.distanceFromCamera > i3) {
+                                                                        i3 = queuedObj.distanceFromCamera;
                                                                         l3 = j5;
-                                                                } else if (class28_2.distanceFromCamera == i3) {
-                                                                        int j7 = class28_2.x - cameraX;
-                                                                        int k8 = class28_2.y - cameraY;
+                                                                } else if (queuedObj.distanceFromCamera == i3) {
+                                                                        int j7 = queuedObj.x - cameraX;
+                                                                        int k8 = queuedObj.y - cameraY;
                                                                         int l9 = sceneObjectBuffer[l3].x - cameraX;
                                                                         int l10 = sceneObjectBuffer[l3].y - cameraY;
                                                                         if (j7 * j7 + k8 * k8 > l9 * l9 + l10 * l10) {
@@ -1351,13 +1351,13 @@ final class WorldController {
 						if (l3 == -1) {
 							break;
 						}
-                                                SceneObject class28_3 = sceneObjectBuffer[l3];
-                                                class28_3.lastDrawn = renderCycle;
-                                                if (!isAreaVisible(l, class28_3.startX, class28_3.endX, class28_3.startY, class28_3.endY, class28_3.renderable.modelHeight)) {
-                                                        class28_3.renderable.render(class28_3.orientation, pitchSin, pitchCos, yawSin, yawCos, class28_3.x - cameraX, class28_3.height - cameraZ, class28_3.y - cameraY, class28_3.uid);
+                                                SceneObject sceneObj = sceneObjectBuffer[l3];
+                                                sceneObj.lastDrawn = renderCycle;
+                                                if (!isAreaVisible(l, sceneObj.startX, sceneObj.endX, sceneObj.startY, sceneObj.endY, sceneObj.renderable.modelHeight)) {
+                                                        sceneObj.renderable.render(sceneObj.orientation, pitchSin, pitchCos, yawSin, yawCos, sceneObj.x - cameraX, sceneObj.height - cameraZ, sceneObj.y - cameraY, sceneObj.uid);
                                                 }
-                                                for (int k7 = class28_3.startX; k7 <= class28_3.endX; k7++) {
-                                                        for (int l8 = class28_3.startY; l8 <= class28_3.endY; l8++) {
+                                                for (int k7 = sceneObj.startX; k7 <= sceneObj.endX; k7++) {
+                                                        for (int l8 = sceneObj.startY; l8 <= sceneObj.endY; l8++) {
                                                                 Ground queuedNeighborTile = planeTiles[k7][l8];
                                                                 if (queuedNeighborTile.cullFlags != 0) {
                                                                         tileQueue.insertHead(queuedNeighborTile);
@@ -1494,7 +1494,7 @@ final class WorldController {
 		} while (true);
 	}
 
-       private void drawPlainTile(PlainTile class43, int i, int j, int k, int l, int i1, int j1, int k1) {
+       private void drawPlainTile(PlainTile tile, int i, int j, int k, int l, int i1, int j1, int k1) {
 		int l1;
 		int i2 = l1 = (j1 << 7) - cameraX;
 		int j2;
@@ -1558,19 +1558,19 @@ final class WorldController {
                                 clickedTileX = j1;
                                 clickedTileY = k1;
                         }
-                        if (class43.textureId == -1) {
-                                if (class43.northEastColor != 0xbc614e) {
-                                        Texture.drawGouraudTriangle(j6, l6, l5, i6, k6, k5, class43.northEastColor, class43.northWestColor, class43.southEastColor);
+                        if (tile.textureId == -1) {
+                                if (tile.northEastColor != 0xbc614e) {
+                                        Texture.drawGouraudTriangle(j6, l6, l5, i6, k6, k5, tile.northEastColor, tile.northWestColor, tile.southEastColor);
                                 }
                         } else if (!lowMem) {
-                                if (class43.flatShade) {
-                                        Texture.drawTexturedTriangle(j6, l6, l5, i6, k6, k5, class43.northEastColor, class43.northWestColor, class43.southEastColor, i2, i3, l1, l3, i4, k4, k2, j2, j3, class43.textureId);
+                                if (tile.flatShade) {
+                                        Texture.drawTexturedTriangle(j6, l6, l5, i6, k6, k5, tile.northEastColor, tile.northWestColor, tile.southEastColor, i2, i3, l1, l3, i4, k4, k2, j2, j3, tile.textureId);
                                 } else {
-                                        Texture.drawTexturedTriangle(j6, l6, l5, i6, k6, k5, class43.northEastColor, class43.northWestColor, class43.southEastColor, l2, l1, i3, j4, k4, i4, k3, j3, j2, class43.textureId);
+                                        Texture.drawTexturedTriangle(j6, l6, l5, i6, k6, k5, tile.northEastColor, tile.northWestColor, tile.southEastColor, l2, l1, i3, j4, k4, i4, k3, j3, j2, tile.textureId);
                                 }
                         } else {
-                                int i7 = textureLookup[class43.textureId];
-                                Texture.drawGouraudTriangle(j6, l6, l5, i6, k6, k5, applyBrightness(i7, class43.northEastColor), applyBrightness(i7, class43.northWestColor), applyBrightness(i7, class43.southEastColor));
+                                int i7 = textureLookup[tile.textureId];
+                                Texture.drawGouraudTriangle(j6, l6, l5, i6, k6, k5, applyBrightness(i7, tile.northEastColor), applyBrightness(i7, tile.northWestColor), applyBrightness(i7, tile.southEastColor));
                         }
 		}
 		if ((i5 - k5) * (l6 - l5) - (j5 - l5) * (k6 - k5) > 0) {
@@ -1579,17 +1579,17 @@ final class WorldController {
                                 clickedTileX = j1;
                                 clickedTileY = k1;
                         }
-                        if (class43.textureId == -1) {
-                                if (class43.southWestColor != 0xbc614e) {
-                                        Texture.drawGouraudTriangle(j5, l5, l6, i5, k5, k6, class43.southWestColor, class43.southEastColor, class43.northWestColor);
+                        if (tile.textureId == -1) {
+                                if (tile.southWestColor != 0xbc614e) {
+                                        Texture.drawGouraudTriangle(j5, l5, l6, i5, k5, k6, tile.southWestColor, tile.southEastColor, tile.northWestColor);
                                 }
                         } else {
                                 if (!lowMem) {
-                                        Texture.drawTexturedTriangle(j5, l5, l6, i5, k5, k6, class43.southWestColor, class43.southEastColor, class43.northWestColor, i2, i3, l1, l3, i4, k4, k2, j2, j3, class43.textureId);
+                                        Texture.drawTexturedTriangle(j5, l5, l6, i5, k5, k6, tile.southWestColor, tile.southEastColor, tile.northWestColor, i2, i3, l1, l3, i4, k4, k2, j2, j3, tile.textureId);
                                         return;
                                 }
-                                int j7 = textureLookup[class43.textureId];
-                                Texture.drawGouraudTriangle(j5, l5, l6, i5, k5, k6, applyBrightness(j7, class43.southWestColor), applyBrightness(j7, class43.southEastColor), applyBrightness(j7, class43.northWestColor));
+                                int j7 = textureLookup[tile.textureId];
+                                Texture.drawGouraudTriangle(j5, l5, l6, i5, k5, k6, applyBrightness(j7, tile.southWestColor), applyBrightness(j7, tile.southEastColor), applyBrightness(j7, tile.northWestColor));
                         }
 		}
 	}
@@ -1687,20 +1687,20 @@ final class WorldController {
 
         private void updateCullingClusters() {
                int j = cullingClusterCounts[cameraPlane];
-               CullingCluster aclass47[] = aCullingClusters[cameraPlane];
+               CullingCluster planeClusters[] = aCullingClusters[cameraPlane];
                cullingClusterBufferCount = 0;
 		for (int k = 0; k < j; k++) {
-			CullingCluster class47 = aclass47[k];
-			if (class47.type == 1) {
-				int l = class47.minTileX - cameraTileX + drawDistance;
+			CullingCluster cluster = planeClusters[k];
+			if (cluster.type == 1) {
+				int l = cluster.minTileX - cameraTileX + drawDistance;
 				if (l < 0 || l > 50) {
 					continue;
 				}
-				int k1 = class47.minTileZ - cameraTileY + drawDistance;
+				int k1 = cluster.minTileZ - cameraTileY + drawDistance;
 				if (k1 < 0) {
 					k1 = 0;
 				}
-				int j2 = class47.maxTileZ - cameraTileY + drawDistance;
+				int j2 = cluster.maxTileZ - cameraTileY + drawDistance;
 				if (j2 > 50) {
 					j2 = 50;
 				}
@@ -1714,33 +1714,33 @@ final class WorldController {
 				if (!flag) {
 					continue;
 				}
-				int j3 = cameraX - class47.minX;
+				int j3 = cameraX - cluster.minX;
 				if (j3 > 32) {
-					class47.searchMask = 1;
+					cluster.searchMask = 1;
 				} else {
 					if (j3 >= -32) {
 						continue;
 					}
-					class47.searchMask = 2;
+					cluster.searchMask = 2;
 					j3 = -j3;
 				}
-				class47.startZFactor = (class47.minZ - cameraY << 8) / j3;
-				class47.endZFactor = (class47.maxZ - cameraY << 8) / j3;
-				class47.startYFactor = (class47.minY - cameraZ << 8) / j3;
-				class47.endYFactor = (class47.maxY - cameraZ << 8) / j3;
-                               cullingClusterBuffer[cullingClusterBufferCount++] = class47;
+				cluster.startZFactor = (cluster.minZ - cameraY << 8) / j3;
+				cluster.endZFactor = (cluster.maxZ - cameraY << 8) / j3;
+				cluster.startYFactor = (cluster.minY - cameraZ << 8) / j3;
+				cluster.endYFactor = (cluster.maxY - cameraZ << 8) / j3;
+                               cullingClusterBuffer[cullingClusterBufferCount++] = cluster;
 				continue;
 			}
-			if (class47.type == 2) {
-				int i1 = class47.minTileZ - cameraTileY + drawDistance;
+			if (cluster.type == 2) {
+				int i1 = cluster.minTileZ - cameraTileY + drawDistance;
 				if (i1 < 0 || i1 > 50) {
 					continue;
 				}
-				int l1 = class47.minTileX - cameraTileX + drawDistance;
+				int l1 = cluster.minTileX - cameraTileX + drawDistance;
 				if (l1 < 0) {
 					l1 = 0;
 				}
-				int k2 = class47.maxTileX - cameraTileX + drawDistance;
+				int k2 = cluster.maxTileX - cameraTileX + drawDistance;
 				if (k2 > 50) {
 					k2 = 50;
 				}
@@ -1754,38 +1754,38 @@ final class WorldController {
 				if (!tileVisible) {
 					continue;
 				}
-				int k3 = cameraY - class47.minZ;
+				int k3 = cameraY - cluster.minZ;
 				if (k3 > 32) {
-					class47.searchMask = 3;
+					cluster.searchMask = 3;
 				} else {
 					if (k3 >= -32) {
 						continue;
 					}
-					class47.searchMask = 4;
+					cluster.searchMask = 4;
 					k3 = -k3;
 				}
-				class47.startXFactor = (class47.minX - cameraX << 8) / k3;
-				class47.endXFactor = (class47.maxX - cameraX << 8) / k3;
-				class47.startYFactor = (class47.minY - cameraZ << 8) / k3;
-				class47.endYFactor = (class47.maxY - cameraZ << 8) / k3;
-                               cullingClusterBuffer[cullingClusterBufferCount++] = class47;
-			} else if (class47.type == 4) {
-				int j1 = class47.minY - cameraZ;
+				cluster.startXFactor = (cluster.minX - cameraX << 8) / k3;
+				cluster.endXFactor = (cluster.maxX - cameraX << 8) / k3;
+				cluster.startYFactor = (cluster.minY - cameraZ << 8) / k3;
+				cluster.endYFactor = (cluster.maxY - cameraZ << 8) / k3;
+                               cullingClusterBuffer[cullingClusterBufferCount++] = cluster;
+			} else if (cluster.type == 4) {
+				int j1 = cluster.minY - cameraZ;
 				if (j1 > 128) {
-					int i2 = class47.minTileZ - cameraTileY + drawDistance;
+					int i2 = cluster.minTileZ - cameraTileY + drawDistance;
 					if (i2 < 0) {
 						i2 = 0;
 					}
-					int l2 = class47.maxTileZ - cameraTileY + drawDistance;
+					int l2 = cluster.maxTileZ - cameraTileY + drawDistance;
 					if (l2 > 50) {
 						l2 = 50;
 					}
 					if (i2 <= l2) {
-						int i3 = class47.minTileX - cameraTileX + drawDistance;
+						int i3 = cluster.minTileX - cameraTileX + drawDistance;
 						if (i3 < 0) {
 							i3 = 0;
 						}
-						int l3 = class47.maxTileX - cameraTileX + drawDistance;
+						int l3 = cluster.maxTileX - cameraTileX + drawDistance;
 						if (l3 > 50) {
 							l3 = 50;
 						}
@@ -1802,12 +1802,12 @@ final class WorldController {
 						}
 
 						if (foundVisible) {
-							class47.searchMask = 5;
-							class47.startXFactor = (class47.minX - cameraX << 8) / j1;
-							class47.endXFactor = (class47.maxX - cameraX << 8) / j1;
-							class47.startZFactor = (class47.minZ - cameraY << 8) / j1;
-							class47.endZFactor = (class47.maxZ - cameraY << 8) / j1;
-                                                   cullingClusterBuffer[cullingClusterBufferCount++] = class47;
+							cluster.searchMask = 5;
+							cluster.startXFactor = (cluster.minX - cameraX << 8) / j1;
+							cluster.endXFactor = (cluster.maxX - cameraX << 8) / j1;
+							cluster.startZFactor = (cluster.minZ - cameraY << 8) / j1;
+							cluster.endZFactor = (cluster.maxZ - cameraY << 8) / j1;
+                                                   cullingClusterBuffer[cullingClusterBufferCount++] = cluster;
 						}
 					}
 				}
@@ -1986,58 +1986,58 @@ final class WorldController {
 
 	private boolean isPointVisible(int i, int j, int k) {
            for (int l = 0; l < cullingClusterBufferCount; l++) {
-			CullingCluster class47 = cullingClusterBuffer[l];
-			if (class47.searchMask == 1) {
-				int i1 = class47.minX - i;
+			CullingCluster cluster = cullingClusterBuffer[l];
+			if (cluster.searchMask == 1) {
+				int i1 = cluster.minX - i;
 				if (i1 > 0) {
-					int j2 = class47.minZ + (class47.startZFactor * i1 >> 8);
-					int k3 = class47.maxZ + (class47.endZFactor * i1 >> 8);
-					int l4 = class47.minY + (class47.startYFactor * i1 >> 8);
-					int i6 = class47.maxY + (class47.endYFactor * i1 >> 8);
+					int j2 = cluster.minZ + (cluster.startZFactor * i1 >> 8);
+					int k3 = cluster.maxZ + (cluster.endZFactor * i1 >> 8);
+					int l4 = cluster.minY + (cluster.startYFactor * i1 >> 8);
+					int i6 = cluster.maxY + (cluster.endYFactor * i1 >> 8);
 					if (k >= j2 && k <= k3 && j >= l4 && j <= i6) {
 						return true;
 					}
 				}
-			} else if (class47.searchMask == 2) {
-				int j1 = i - class47.minX;
+			} else if (cluster.searchMask == 2) {
+				int j1 = i - cluster.minX;
 				if (j1 > 0) {
-					int k2 = class47.minZ + (class47.startZFactor * j1 >> 8);
-					int l3 = class47.maxZ + (class47.endZFactor * j1 >> 8);
-					int i5 = class47.minY + (class47.startYFactor * j1 >> 8);
-					int j6 = class47.maxY + (class47.endYFactor * j1 >> 8);
+					int k2 = cluster.minZ + (cluster.startZFactor * j1 >> 8);
+					int l3 = cluster.maxZ + (cluster.endZFactor * j1 >> 8);
+					int i5 = cluster.minY + (cluster.startYFactor * j1 >> 8);
+					int j6 = cluster.maxY + (cluster.endYFactor * j1 >> 8);
 					if (k >= k2 && k <= l3 && j >= i5 && j <= j6) {
 						return true;
 					}
 				}
-			} else if (class47.searchMask == 3) {
-				int k1 = class47.minZ - k;
+			} else if (cluster.searchMask == 3) {
+				int k1 = cluster.minZ - k;
 				if (k1 > 0) {
-					int l2 = class47.minX + (class47.startXFactor * k1 >> 8);
-					int i4 = class47.maxX + (class47.endXFactor * k1 >> 8);
-					int j5 = class47.minY + (class47.startYFactor * k1 >> 8);
-					int k6 = class47.maxY + (class47.endYFactor * k1 >> 8);
+					int l2 = cluster.minX + (cluster.startXFactor * k1 >> 8);
+					int i4 = cluster.maxX + (cluster.endXFactor * k1 >> 8);
+					int j5 = cluster.minY + (cluster.startYFactor * k1 >> 8);
+					int k6 = cluster.maxY + (cluster.endYFactor * k1 >> 8);
 					if (i >= l2 && i <= i4 && j >= j5 && j <= k6) {
 						return true;
 					}
 				}
-			} else if (class47.searchMask == 4) {
-				int l1 = k - class47.minZ;
+			} else if (cluster.searchMask == 4) {
+				int l1 = k - cluster.minZ;
 				if (l1 > 0) {
-					int i3 = class47.minX + (class47.startXFactor * l1 >> 8);
-					int j4 = class47.maxX + (class47.endXFactor * l1 >> 8);
-					int k5 = class47.minY + (class47.startYFactor * l1 >> 8);
-					int l6 = class47.maxY + (class47.endYFactor * l1 >> 8);
+					int i3 = cluster.minX + (cluster.startXFactor * l1 >> 8);
+					int j4 = cluster.maxX + (cluster.endXFactor * l1 >> 8);
+					int k5 = cluster.minY + (cluster.startYFactor * l1 >> 8);
+					int l6 = cluster.maxY + (cluster.endYFactor * l1 >> 8);
 					if (i >= i3 && i <= j4 && j >= k5 && j <= l6) {
 						return true;
 					}
 				}
-			} else if (class47.searchMask == 5) {
-				int i2 = j - class47.minY;
+			} else if (cluster.searchMask == 5) {
+				int i2 = j - cluster.minY;
 				if (i2 > 0) {
-					int j3 = class47.minX + (class47.startXFactor * i2 >> 8);
-					int k4 = class47.maxX + (class47.endXFactor * i2 >> 8);
-					int l5 = class47.minZ + (class47.startZFactor * i2 >> 8);
-					int i7 = class47.maxZ + (class47.endZFactor * i2 >> 8);
+					int j3 = cluster.minX + (cluster.startXFactor * i2 >> 8);
+					int k4 = cluster.maxX + (cluster.endXFactor * i2 >> 8);
+					int l5 = cluster.minZ + (cluster.startZFactor * i2 >> 8);
+					int i7 = cluster.maxZ + (cluster.endZFactor * i2 >> 8);
 					if (i >= j3 && i <= k4 && k >= l5 && k <= i7) {
 						return true;
 					}

--- a/rename-history.md
+++ b/rename-history.md
@@ -77,6 +77,17 @@ This document lists variable or identifier renames found in the commit history.
 - class10_3 -> boundaryObj
 - class10 -> boundaryObject
 - class49 -> tileDecoration
+- aclass47 -> planeClusters
+- class47 -> cluster
+- class33 -> normal
+- class33_1 -> tempNormal
+- class33_2 -> otherNormal
+- class33_3 -> otherTempNormal
+- class43 -> tile
+- class43_1 -> alternateTile
+- class28_1 -> objTile
+- class28_2 -> queuedObj
+- class28_3 -> sceneObj
 
 ## Ground
 - aBoolean1322 -> tileActive
@@ -447,8 +458,9 @@ This document lists variable or identifier renames found in the commit history.
 ## Object5 -> SceneObject
 
 ## Animable_Sub5 -> DynamicObject
- - method258 -> getFrameDelay
- - anInt811 -> tileHeight
+- method258 -> getFrameDelay
+- anInt811 -> tileHeight
+- class46 -> objectDef
 
 ## Object2 -> WallDecoration
  - aClass30_Sub2_Sub4_814 -> renderable
@@ -541,6 +553,7 @@ This document lists variable or identifier renames found in the commit history.
 ## Object3 -> TileDecoration
 
 ## Class13 -> BZip2Decompressor
+ - class32 -> state
 
 ## Kotlin -> Java
 
@@ -575,7 +588,7 @@ This document lists variable or identifier renames found in the commit history.
 - aclass11 -> collisionMaps
 - class11 -> collisionMap
 - class42_sub1 -> onDemandFetcher
-- class46 -> objectDefinition
+ - class46 -> objectDef
 - obj -> tileDecoration
 - obj1 -> dynamicObject
 - obj2 -> genericObject
@@ -620,6 +633,7 @@ This document lists variable or identifier renames found in the commit history.
 ## Class43 -> ModelHeader
 
 ## Class6 -> SoundFilter
+ - class29 -> envelope
 
 ## Class39 -> Instrument
 


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) |        |
| `spotbugs:check` passes             |        |
| ≥ 80 % coverage on touched lines    |        |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Refactors several obfuscated variable names across the client to improve readability.

## 🗂️ Detailed Changes
- renamed local variables in `DynamicObject`, `BZip2Decompressor`, `SoundFilter`, and `WorldController`
- updated all references within those classes
- recorded mappings in `rename-history.md`

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
| class46 | objectDef |
| class32 | state |
| class29 | envelope |
| aclass47 | planeClusters |
| class47 | cluster |
| class33 | normal |
| class33_1 | tempNormal |
| class33_2 | otherNormal |
| class33_3 | otherTempNormal |
| class43 | tile |
| class43_1 | alternateTile |
| class28_1 | objTile |
| class28_2 | queuedObj |
| class28_3 | sceneObj |

- **Batch**: 
- **Revert command**: `git revert -m 1 e57b4d`

## 📊 Diff Stat
```text
.../src/main/java/BZip2Decompressor.java | 310 ++++++++++-----------
2006Scape Client/src/main/java/DynamicObject.java | 30 +- 
2006Scape Client/src/main/java/SoundFilter.java | 4 +- 
.../src/main/java/WorldController.java | 266 +++++++++---------
rename-history.md | 20 +- 
5 files changed, 322 insertions(+), 308 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded with warnings using the project command.

## 📝 Rollback Plan
If this PR causes issues on `main`, revert with the command above.

------
https://chatgpt.com/codex/tasks/task_e_6875fb483abc832bb0899e47fb4c9f0b