### PR TITLE
[BOT] docs: add legal disclaimer

### DIFF
--- a/docs/disclaimer.md
+++ b/docs/disclaimer.md
@@ -1,0 +1,5 @@
+# Legal Disclaimer
+
+2006Scape is an open source project created by fans. It is not affiliated with or endorsed by Jagex Ltd. RuneScape and RuneScape Classic are trademarks of Jagex Ltd. All game content remains the property of its respective owners.
+
+This software is provided for educational and archival purposes. Use it responsibly and at your own risk.

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
                 <li><a href="#" data-md="Client/client-intro.md">Client</a></li>
                 <li><a href="#" data-md="Server/Server-intro.md">Server</a></li>
                 <li><a href="#" data-md="Parabot/Parabot-intro.md">Parabot</a></li>
+                <li><a href="#" data-md="disclaimer.md">Disclaimer</a></li>
                 <li><a href="#" data-md="../README.md">Repo README</a></li>
                 <li><a href="#" data-md="../AGENTS.md">Agents</a></li>
             </ul>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,4 @@ Welcome to the 2006Scape documentation. These pages provide an overview of the p
 - [Client Docs](Client/client-intro.md) – information about the game client
 - [Server Docs](Server/Server-intro.md) – server architecture
 - [Parabot Docs](Parabot/Parabot-intro.md) – scripting client details
+- [Legal Disclaimer](disclaimer.md) – project affiliation notice


### PR DESCRIPTION
## Summary
- create a disclaimer page
- link the disclaimer from the docs landing page
- add disclaimer entry to the docs navigation

## Testing
- `git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac`

------
https://chatgpt.com/codex/tasks/task_e_6879cbf49628832b9bdc366978a2ee61