### PR TITLE
[BOT] test: add client coverage

### DIFF
--- a/2006Scape Client/src/test/java/core/LocalGameTest.java
+++ b/2006Scape Client/src/test/java/core/LocalGameTest.java
@@ -1,0 +1,13 @@
+package core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LocalGameTest {
+    @Test
+    public void testConstructorSetsLocalhostServer() {
+        new LocalGame();
+        assertEquals("127.0.0.1", Game.server);
+    }
+}

--- a/2006Scape Client/src/test/java/render/ModelHeaderTest.java
+++ b/2006Scape Client/src/test/java/render/ModelHeaderTest.java
@@ -1,0 +1,29 @@
+package render;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ModelHeaderTest {
+    @Test
+    public void testDefaultsAfterConstruction() {
+        ModelHeader header = new ModelHeader();
+        assertNull(header.data);
+        assertEquals(0, header.vertexCount);
+        assertEquals(0, header.faceCount);
+        assertEquals(0, header.texturedTriangleCount);
+        assertEquals(0, header.vertexFlagsOffset);
+        assertEquals(0, header.vertexXOffset);
+        assertEquals(0, header.vertexYOffset);
+        assertEquals(0, header.vertexZOffset);
+        assertEquals(0, header.vertexSkinsOffset);
+        assertEquals(0, header.faceTypeOffset);
+        assertEquals(0, header.facePriorityOffset);
+        assertEquals(0, header.faceSkinOffset);
+        assertEquals(0, header.faceLabelOffset);
+        assertEquals(0, header.faceAlphaOffset);
+        assertEquals(0, header.faceTextureOffset);
+        assertEquals(0, header.vertexLabelOffset);
+        assertEquals(0, header.faceIndicesOffset);
+    }
+}

--- a/2006Scape Client/src/test/java/render/PlainTileTest.java
+++ b/2006Scape Client/src/test/java/render/PlainTileTest.java
@@ -1,0 +1,19 @@
+package render;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PlainTileTest {
+    @Test
+    public void testConstructorSetsFields() {
+        PlainTile tile = new PlainTile(1, 2, 3, 4, 5, 6, false);
+        assertEquals(1, tile.southWestColor);
+        assertEquals(2, tile.southEastColor);
+        assertEquals(3, tile.northEastColor);
+        assertEquals(4, tile.northWestColor);
+        assertEquals(5, tile.textureId);
+        assertEquals(6, tile.orientation);
+        assertFalse(tile.flatShade);
+    }
+}

--- a/2006Scape Client/src/test/java/render/SceneObjectTest.java
+++ b/2006Scape Client/src/test/java/render/SceneObjectTest.java
@@ -1,0 +1,20 @@
+package render;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SceneObjectTest {
+    @Test
+    public void testDefaultsAfterConstruction() {
+        SceneObject obj = new SceneObject();
+        assertEquals(0, obj.plane);
+        assertEquals(0, obj.height);
+        assertEquals(0, obj.x);
+        assertEquals(0, obj.y);
+        assertNull(obj.renderable);
+        assertEquals(0, obj.orientation);
+        assertEquals(0, obj.uid);
+        assertEquals(0, obj.config);
+    }
+}

--- a/2006Scape Client/src/test/java/render/TileDecorationTest.java
+++ b/2006Scape Client/src/test/java/render/TileDecorationTest.java
@@ -1,0 +1,18 @@
+package render;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TileDecorationTest {
+    @Test
+    public void testDefaultsAfterConstruction() {
+        TileDecoration d = new TileDecoration();
+        assertEquals(0, d.tileHeight);
+        assertEquals(0, d.x);
+        assertEquals(0, d.y);
+        assertNull(d.renderable);
+        assertEquals(0, d.uid);
+        assertEquals(0, d.config);
+    }
+}

--- a/2006Scape Client/src/test/java/render/WallDecorationTest.java
+++ b/2006Scape Client/src/test/java/render/WallDecorationTest.java
@@ -1,0 +1,20 @@
+package render;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WallDecorationTest {
+    @Test
+    public void testDefaultsAfterConstruction() {
+        WallDecoration d = new WallDecoration();
+        assertEquals(0, d.plane);
+        assertEquals(0, d.x);
+        assertEquals(0, d.y);
+        assertEquals(0, d.orientationFlags);
+        assertEquals(0, d.orientation);
+        assertNull(d.renderable);
+        assertEquals(0, d.uid);
+        assertEquals(0, d.config);
+    }
+}

--- a/2006Scape Client/src/test/java/ui/TextClassTest.java
+++ b/2006Scape Client/src/test/java/ui/TextClassTest.java
@@ -1,0 +1,41 @@
+package ui;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TextClassTest {
+    @Test
+    public void testLongForNameCaseInsensitive() {
+        long upper = TextClass.longForName("RuneBot");
+        long lower = TextClass.longForName("runebot");
+        assertEquals(upper, lower);
+    }
+
+    @Test
+    public void testNameForLongRoundTrip() {
+        long value = TextClass.longForName("RuneBot");
+        assertEquals("runebot", TextClass.nameForLong(value));
+    }
+
+    @Test
+    public void testHashSpriteNameDeterministic() {
+        assertEquals(11943852L, TextClass.hashSpriteName("test"));
+        assertEquals(TextClass.hashSpriteName("TEST"), TextClass.hashSpriteName("test"));
+    }
+
+    @Test
+    public void testIntToIpString() {
+        assertEquals("127.0.0.1", TextClass.intToIpString(0x7F000001));
+    }
+
+    @Test
+    public void testFixName() {
+        assertEquals("Hello World", TextClass.fixName("hello_world"));
+    }
+
+    @Test
+    public void testPasswordAsterisks() {
+        assertEquals("******", TextClass.passwordAsterisks("secret"));
+    }
+}


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

> **PR Title format**: `[BOT] <type(scope)>: <summary>`

---

## ✅ Pre‑flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | N/A |
| `spotbugs:check` passes             | N/A |
| ≥ 80 % coverage on touched lines    | N/A |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

---

## 🔍 What & Why

Added unit tests for previously uncovered client classes to improve reliability and ensure core functionality remains stable.

---

## 🗂️ Detailed Changes

- Added `LocalGameTest` verifying localhost server configuration.
- Added `TextClassTest` covering utility methods such as name hashing and IP conversion.
- Added tests for simple render classes (`PlainTile`, `TileDecoration`, `SceneObject`, `WallDecoration`, and `ModelHeader`).

---

## 📊 Diff Stat

```text
.../src/test/java/core/LocalGameTest.java          | 13 +++++++
.../src/test/java/render/ModelHeaderTest.java      | 29 +++++++++++++++
.../src/test/java/render/PlainTileTest.java        | 19 ++++++++++
.../src/test/java/render/SceneObjectTest.java      | 20 +++++++++++
.../src/test/java/render/TileDecorationTest.java   | 18 ++++++++++
.../src/test/java/render/WallDecorationTest.java   | 20 +++++++++++
.../src/test/java/ui/TextClassTest.java            | 41 ++++++++++++++++++++++
7 files changed, 160 insertions(+)
```

---

## 🧪 Integration‑Test Log

Compilation successful using `javac` as per repo instructions.

---

## 📝 Rollback Plan

If this PR causes a failure on `main`, the bot will automatically open a revert PR following Section 9 of **AGENTS.md**.

------
https://chatgpt.com/codex/tasks/task_e_687eaa1d6408832ba4383602c79c4eb6