### PR TITLE
[BOT] refactor(game): extract cache utilities

### DIFF
--- a/2006Scape Client/src/main/java/core/CacheUtils.java
+++ b/2006Scape Client/src/main/java/core/CacheUtils.java
@@ -1,0 +1,66 @@
+package core;
+
+import net.Signlink;
+import util.Decompressor;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+/**
+ * Utility methods for cache file operations extracted from {@link Game}.
+ */
+public final class CacheUtils {
+
+    private CacheUtils() {}
+
+    public static String getFileNameWithoutExtension(String fileName) {
+        File tmpFile = new File(fileName);
+        tmpFile.getName();
+        int whereDot = tmpFile.getName().lastIndexOf('.');
+        if (0 < whereDot && whereDot <= tmpFile.getName().length() - 2) {
+            return tmpFile.getName().substring(0, whereDot);
+        }
+        return "";
+    }
+
+    public static String indexLocation(int cacheIndex, int index) {
+        return Signlink.findcachedir() + "index" + cacheIndex + "/" + (index != -1 ? index + ".gz" : "");
+    }
+
+    public static void repackCacheIndex(int cacheIndex, Decompressor[] decompressors) {
+        System.out.println("Started repacking index " + cacheIndex + ".");
+        int indexLength = new File(indexLocation(cacheIndex, -1)).listFiles().length;
+        File[] file = new File(indexLocation(cacheIndex, -1)).listFiles();
+        try {
+            for (int idx = 0; idx < indexLength; idx++) {
+                int fileIndex = Integer.parseInt(getFileNameWithoutExtension(file[idx].toString()));
+                byte[] data = fileToByteArray(cacheIndex, fileIndex);
+                if (data != null && data.length > 0) {
+                    decompressors[cacheIndex].writeEntry(data.length, data, fileIndex);
+                    System.out.println("Repacked " + fileIndex + ".");
+                } else {
+                    System.out.println("Unable to locate index " + fileIndex + ".");
+                }
+            }
+        } catch (Exception e) {
+            System.out.println("Error packing cache index " + cacheIndex + ".");
+        }
+        System.out.println("Finished repacking " + cacheIndex + ".");
+    }
+
+    public static byte[] fileToByteArray(int cacheIndex, int index) {
+        try {
+            if (indexLocation(cacheIndex, index).length() <= 0 || indexLocation(cacheIndex, index) == null) {
+                return null;
+            }
+            File file = new File(indexLocation(cacheIndex, index));
+            byte[] fileData = new byte[(int) file.length()];
+            FileInputStream fis = new FileInputStream(file);
+            fis.read(fileData);
+            fis.close();
+            return fileData;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/2006Scape Client/src/main/java/core/Game.java
+++ b/2006Scape Client/src/main/java/core/Game.java
@@ -131,56 +131,6 @@ public class Game extends RSApplet {
 		}
 	}
 	
-	public static String getFileNameWithoutExtension(String fileName) {
-		File tmpFile = new File(fileName);
-		tmpFile.getName();
-		int whereDot = tmpFile.getName().lastIndexOf('.');
-		if (0 < whereDot && whereDot <= tmpFile.getName().length() - 2) {
-			return tmpFile.getName().substring(0, whereDot);
-		}
-		return "";
-	}
-	
-	public String indexLocation(int cacheIndex, int index) {
-		return Signlink.findcachedir() + "index" + cacheIndex + "/" + (index != -1 ? index + ".gz" : "");
-	}
-
-	public void repackCacheIndex(int cacheIndex) {
-		System.out.println("Started repacking index " + cacheIndex + ".");
-		int indexLength = new File(indexLocation(cacheIndex, -1)).listFiles().length;
-		File[] file = new File(indexLocation(cacheIndex, -1)).listFiles();
-		try {
-			for (int index = 0; index < indexLength; index++) {
-				int fileIndex = Integer.parseInt(getFileNameWithoutExtension(file[index].toString()));
-				byte[] data = fileToByteArray(cacheIndex, fileIndex);
-				if(data != null && data.length > 0) {
-                                        decompressors[cacheIndex].writeEntry(data.length, data, fileIndex);
-					System.out.println("Repacked " + fileIndex + ".");
-				} else {
-					System.out.println("Unable to locate index " + fileIndex + ".");
-				}
-			}
-		} catch(Exception e) {
-			System.out.println("Error packing cache index " + cacheIndex + ".");
-		}
-		System.out.println("Finished repacking " + cacheIndex + ".");
-	}
-
-	public byte[] fileToByteArray(int cacheIndex, int index) {
-		try {
-			if (indexLocation(cacheIndex, index).length() <= 0 || indexLocation(cacheIndex, index) == null) {
-				return null;
-			}
-			File file = new File(indexLocation(cacheIndex, index));
-			byte[] fileData = new byte[(int)file.length()];
-			FileInputStream fis = new FileInputStream(file);
-			fis.read(fileData);
-			fis.close();
-			return fileData;
-		} catch(Exception e) {
-			return null;
-		}
-	}
 	
 	public void musics() {
 		for(int MusicIndex = 0; MusicIndex < 3536; MusicIndex++) {
@@ -7063,7 +7013,7 @@ public class Game extends RSApplet {
                         TextDrawingArea smallFont = new TextDrawingArea(true, "q8_full", titleStreamLoader);
 			drawLogo();
 			loadTitleScreen();
-			//repackCacheIndex(1);
+			//CacheUtils.repackCacheIndex(1, decompressors);
 			constructMusic();
 			StreamLoader streamLoader = streamLoaderForName(2, "config", "config", expectedCRCs[2], 30);
 			StreamLoader streamLoader_1 = streamLoaderForName(3, "interface", "interface", expectedCRCs[3], 35);

--- a/docs/Client/classes/CacheUtils.md
+++ b/docs/Client/classes/CacheUtils.md
@@ -1,0 +1,14 @@
+# CacheUtils
+
+Defined in [`2006Scape Client/src/main/java/core/CacheUtils.java`](2006Scape Client/src/main/java/core/CacheUtils.java).
+
+Utility methods for reading and repacking cache files.
+
+```java
+public final class CacheUtils {
+    public static String getFileNameWithoutExtension(String fileName)
+    public static String indexLocation(int cacheIndex, int index)
+    public static void repackCacheIndex(int cacheIndex, Decompressor[] decompressors)
+    public static byte[] fileToByteArray(int cacheIndex, int index)
+}
+```

--- a/docs/Client/classes/Game.md
+++ b/docs/Client/classes/Game.md
@@ -8,10 +8,6 @@ NOTICE: IF YOU CHANGE ANYTHING IN GAME.JAVA, PLEASE COPY-PASTE THE WHOLE CLASS O
 public class Game extends RSApplet {
 public static int random(final float range)
 public static String intToKOrMilLongName(int i)
-public static String getFileNameWithoutExtension(String fileName)
-public String indexLocation(int cacheIndex, int index)
-public void repackCacheIndex(int cacheIndex)
-public byte[] fileToByteArray(int cacheIndex, int index)
 public void musics()
 public byte[] GetMusic(int Index)
 public void sendFrame126(String str,int i)

--- a/docs/Client/index.md
+++ b/docs/Client/index.md
@@ -8,6 +8,7 @@
 - [Background](Client/classes/Background.md)
 - [BoundaryObject](Client/classes/BoundaryObject.md)
 - [CachePlaceholder](Client/classes/CachePlaceholder.md)
+- [CacheUtils](Client/classes/CacheUtils.md)
 - [Censor](Client/classes/Censor.md)
 - [Client](Client/classes/Client.md)
 - [ClientSettings](Client/classes/ClientSettings.md)


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist
| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes             | ❌ |
| ≥ 80 % coverage on touched lines    | ❌ |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Extracted several cache helper methods from the oversized `Game` class into a new `CacheUtils` utility. This is the first step towards breaking down the client god class into smaller units.

## 🗂️ Detailed Changes
- Added `CacheUtils` with methods for path generation, file reading and cache repacking.
- Removed the corresponding methods from `Game`.
- Updated documentation and class index to reference the new utility.

## ♻️ Rename-Specific Fields
| Old Identifier | New Identifier |
| -------------- | -------------- |
|                |                |

- **Batch**:
- **Revert command**: `git revert -m 1 be1f257b824609d2f5c0217b97a8e45a1bfa705e`

## 📊 Diff Stat
```text
 .../src/main/java/core/CacheUtils.java             | 66 ++++++++++++++++++++++
 2006Scape Client/src/main/java/core/Game.java      | 52 +----------------
 docs/Client/classes/CacheUtils.md                  | 14 +++++
 docs/Client/classes/Game.md                        |  4 --
 docs/Client/index.md                               |  5 +-
 5 files changed, 84 insertions(+), 57 deletions(-)
```

## 🧪 Integration-Test Log
N/A

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of **AGENTS.md** applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_687eb337d33c832ba4c49e1b0fb61215