### PR TITLE
[BOT] refactor(core): extract chat renderer

### DIFF
--- a/2006Scape Client/src/main/java/core/ChatAreaRenderer.java
+++ b/2006Scape Client/src/main/java/core/ChatAreaRenderer.java
@@ -1,0 +1,154 @@
+package core;
+
+import render.DrawingArea;
+import render.Texture;
+import ui.RSInterface;
+import ui.TextClass;
+import ui.TextDrawingArea;
+
+/**
+ * Renders the game's chat area. Extracted from {@link Game} for readability.
+ */
+final class ChatAreaRenderer {
+    private final Game game;
+
+    ChatAreaRenderer(Game game) {
+        this.game = game;
+    }
+
+    void drawChatArea() {
+        game.fullScreenBackground.initDrawingArea();
+        Texture.lineOffsets = game.chatAreaOffsets;
+        game.chatBack.draw(0, 0);
+        if (game.messagePromptRaised) {
+            game.chatTextDrawingArea.textCenter(0, game.inputPrompt, 40, 239);
+            game.chatTextDrawingArea.textCenter(128, game.promptInput + "*", 60, 239);
+        } else if (game.inputDialogState == 1) {
+            game.chatTextDrawingArea.textCenter(0, "Enter amount:", 40, 239);
+            game.chatTextDrawingArea.textCenter(128, game.amountOrNameInput + "*", 60, 239);
+        } else if (game.inputDialogState == 2) {
+            game.chatTextDrawingArea.textCenter(0, "Enter name:", 40, 239);
+            game.chatTextDrawingArea.textCenter(128, game.amountOrNameInput + "*", 60, 239);
+        } else if (game.messagePrompt != null) {
+            game.chatTextDrawingArea.textCenter(0, game.messagePrompt, 40, 239);
+            game.chatTextDrawingArea.textCenter(128, "Click to continue", 60, 239);
+        } else if (game.backDialogID != -1) {
+            game.drawInterface(0, 0, RSInterface.interfaceCache[game.backDialogID], 0);
+        } else if (game.dialogID != -1) {
+            game.drawInterface(0, 0, RSInterface.interfaceCache[game.dialogID], 0);
+        } else {
+            TextDrawingArea textDrawingArea = game.boldFont;
+            int j = 0;
+            DrawingArea.setDrawingArea(77, 0, 463, 0);
+            for (int k = 0; k < 100; k++) {
+                if (game.chatMessages[k] != null) {
+                    int l = game.chatTypes[k];
+                    int i1 = 70 - j * 14 + game.chatScrollPosition;
+                    String s1 = game.chatNames[k];
+                    byte byte0 = 0;
+                    if (s1 != null && s1.startsWith("@cr1@")) {
+                        s1 = s1.substring(5);
+                        byte0 = 1;
+                    }
+                    if (s1 != null && s1.startsWith("@cr2@")) {
+                        s1 = s1.substring(5);
+                        byte0 = 2;
+                    }
+                    if (l == 0) {
+                        if (i1 > 0 && i1 < 110) {
+                            try {
+                                textDrawingArea.textLeftShadow(false, 4, 0, game.chatMessages[k], i1);
+                            } catch (Exception e) {
+                                // ignore drawing exceptions
+                            }
+                        }
+                        j++;
+                    }
+                    if ((l == 1 || l == 2) && (l == 1 || game.publicChatMode == 0 || game.publicChatMode == 1 && game.isFriendOrSelf(s1))) {
+                        if (i1 > 0 && i1 < 110) {
+                            int j1 = 4;
+                            if (byte0 == 1) {
+                                game.modIcons[0].draw(j1, i1 - 12);
+                                j1 += 14;
+                            }
+                            if (byte0 == 2) {
+                                game.modIcons[1].draw(j1, i1 - 12);
+                                j1 += 14;
+                            }
+                            textDrawingArea.textLeft(0, s1 + ":", i1, j1);
+                            j1 += textDrawingArea.getTextWidth(s1) + 8;
+                            textDrawingArea.textLeft(255, game.chatMessages[k], i1, j1);
+                        }
+                        j++;
+                    }
+                    if ((l == 3 || l == 7) && game.splitpublicChat == 0 && (l == 7 || game.privateChatMode == 0 || game.privateChatMode == 1 && game.isFriendOrSelf(s1))) {
+                        if (i1 > 0 && i1 < 110) {
+                            int k1 = 4;
+                            textDrawingArea.textLeft(0, "From", i1, k1);
+                            k1 += textDrawingArea.getTextWidth("From ");
+                            if (byte0 == 1) {
+                                game.modIcons[0].draw(k1, i1 - 12);
+                                k1 += 14;
+                            }
+                            if (byte0 == 2) {
+                                game.modIcons[1].draw(k1, i1 - 12);
+                                k1 += 14;
+                            }
+                            textDrawingArea.textLeft(0, s1 + ":", i1, k1);
+                            k1 += textDrawingArea.getTextWidth(s1) + 8;
+                            textDrawingArea.textLeft(0x800000, game.chatMessages[k], i1, k1);
+                        }
+                        j++;
+                    }
+                    if (l == 4 && (game.tradeMode == 0 || game.tradeMode == 1 && game.isFriendOrSelf(s1))) {
+                        if (i1 > 0 && i1 < 110) {
+                            textDrawingArea.textLeft(0x800080, s1 + " " + game.chatMessages[k], i1, 4);
+                        }
+                        j++;
+                    }
+                    if (l == 5 && game.splitpublicChat == 0 && game.privateChatMode < 2) {
+                        if (i1 > 0 && i1 < 110) {
+                            textDrawingArea.textLeft(0x800000, game.chatMessages[k], i1, 4);
+                        }
+                        j++;
+                    }
+                    if (l == 6 && game.splitpublicChat == 0 && game.privateChatMode < 2) {
+                        if (i1 > 0 && i1 < 110) {
+                            textDrawingArea.textLeft(0, "To " + s1 + ":", i1, 4);
+                            textDrawingArea.textLeft(0x800000, game.chatMessages[k], i1, 12 + textDrawingArea.getTextWidth("To " + s1));
+                        }
+                        j++;
+                    }
+                    if (l == 8 && (game.tradeMode == 0 || game.tradeMode == 1 && game.isFriendOrSelf(s1))) {
+                        if (i1 > 0 && i1 < 110) {
+                            textDrawingArea.textLeft(0x7e3200, s1 + " " + game.chatMessages[k], i1, 4);
+                        }
+                        j++;
+                    }
+                }
+            }
+
+            DrawingArea.defaultDrawingAreaSize();
+            game.chatScrollHeight = j * 14 + 7;
+            if (game.chatScrollHeight < 78) {
+                game.chatScrollHeight = 78;
+            }
+            game.drawScrollThumb(77, game.chatScrollHeight - game.chatScrollPosition - 77, 0, 463, game.chatScrollHeight);
+            String s;
+            if (game.myPlayer != null && game.myPlayer.name != null) {
+                s = game.myPlayer.name;
+            } else {
+                s = TextClass.fixName(game.myUsername);
+            }
+            textDrawingArea.textLeft(0, s + ":", 90, 4);
+            textDrawingArea.textLeft(255, game.inputString + "*", 90, 6 + textDrawingArea.getTextWidth(s + ": "));
+            DrawingArea.drawHorizontalLine(77, 0, 479, 0);
+        }
+        if (game.menuOpen && game.menuScreenArea == 2) {
+            game.drawMenu();
+        }
+        game.fullScreenBackground.drawGraphics(357, game.graphics, 17);
+        game.tabAreaBuffer.initDrawingArea();
+        Texture.lineOffsets = game.chatBoxAreaOffsets;
+    }
+}

--- a/2006Scape Client/src/main/java/core/Game.java
+++ b/2006Scape Client/src/main/java/core/Game.java
@@ -57,6 +57,7 @@ import net.RSSocket;
 import net.Signlink;
 import net.Stream;
 import core.MusicSystem;
+import core.ChatAreaRenderer;
 import render.Background;
 import render.BoundaryObject;
 import render.CollisionMap;
@@ -217,141 +218,9 @@ static final boolean constructMusic() {
 		return k == 337;
 	}
 
-	public void drawChatArea() {
-		fullScreenBackground.initDrawingArea();
-		Texture.lineOffsets = chatAreaOffsets;
-		chatBack.draw(0, 0);
-		if (messagePromptRaised) {
-			chatTextDrawingArea.textCenter(0, inputPrompt, 40, 239);
-			chatTextDrawingArea.textCenter(128, promptInput + "*", 60, 239);
-		} else if (inputDialogState == 1) {
-			chatTextDrawingArea.textCenter(0, "Enter amount:", 40, 239);
-			chatTextDrawingArea.textCenter(128, amountOrNameInput + "*", 60, 239);
-		} else if (inputDialogState == 2) {
-			chatTextDrawingArea.textCenter(0, "Enter name:", 40, 239);
-			chatTextDrawingArea.textCenter(128, amountOrNameInput + "*", 60, 239);
-		} else if (messagePrompt != null) {
-			chatTextDrawingArea.textCenter(0, messagePrompt, 40, 239);
-			chatTextDrawingArea.textCenter(128, "Click to continue", 60, 239);
-		} else if (backDialogID != -1) {
-			drawInterface(0, 0, RSInterface.interfaceCache[backDialogID], 0);//CHANGED THIS - andrew was 0, 0
-		} else if (dialogID != -1) {
-			drawInterface(0, 0, RSInterface.interfaceCache[dialogID], 0);//CHANGED THIS - andrew was 0, 0
-		} else {
-			TextDrawingArea textDrawingArea = boldFont;
-			int j = 0;
-			DrawingArea.setDrawingArea(77, 0, 463, 0);
-			for (int k = 0; k < 100; k++) {
-				if (chatMessages[k] != null) {
-					int l = chatTypes[k];
-					int i1 = 70 - j * 14 + chatScrollPosition;
-					String s1 = chatNames[k];
-					byte byte0 = 0;
-					if (s1 != null && s1.startsWith("@cr1@")) {
-						s1 = s1.substring(5);
-						byte0 = 1;
-					}
-					if (s1 != null && s1.startsWith("@cr2@")) {
-						s1 = s1.substring(5);
-						byte0 = 2;
-					}
-					if (l == 0) {
-						if (i1 > 0 && i1 < 110) {
-							try {
-							textDrawingArea.textLeftShadow(false, 4, 0, chatMessages[k], i1);
-							} catch (Exception e) {
-								
-							}
-						}
-						j++;
-					}
-					if ((l == 1 || l == 2) && (l == 1 || publicChatMode == 0 || publicChatMode == 1 && isFriendOrSelf(s1))) {
-						if (i1 > 0 && i1 < 110) {
-							int j1 = 4;
-							if (byte0 == 1) {
-								modIcons[0].draw(j1, i1 - 12);
-								j1 += 14;
-							}
-							if (byte0 == 2) {
-								modIcons[1].draw(j1, i1 - 12);
-								j1 += 14;
-							}
-							textDrawingArea.textLeft(0, s1 + ":", i1, j1);
-							j1 += textDrawingArea.getTextWidth(s1) + 8;
-							textDrawingArea.textLeft(255, chatMessages[k], i1, j1);
-						}
-						j++;
-					}
-					if ((l == 3 || l == 7) && splitpublicChat == 0 && (l == 7 || privateChatMode == 0 || privateChatMode == 1 && isFriendOrSelf(s1))) {
-						if (i1 > 0 && i1 < 110) {
-							int k1 = 4;
-							textDrawingArea.textLeft(0, "From", i1, k1);
-							k1 += textDrawingArea.getTextWidth("From ");
-							if (byte0 == 1) {
-								modIcons[0].draw(k1, i1 - 12);
-								k1 += 14;
-							}
-							if (byte0 == 2) {
-								modIcons[1].draw(k1, i1 - 12);
-								k1 += 14;
-							}
-							textDrawingArea.textLeft(0, s1 + ":", i1, k1);
-							k1 += textDrawingArea.getTextWidth(s1) + 8;
-							textDrawingArea.textLeft(0x800000, chatMessages[k], i1, k1);
-						}
-						j++;
-					}
-					if (l == 4 && (tradeMode == 0 || tradeMode == 1 && isFriendOrSelf(s1))) {
-						if (i1 > 0 && i1 < 110) {
-							textDrawingArea.textLeft(0x800080, s1 + " " + chatMessages[k], i1, 4);
-						}
-						j++;
-					}
-					if (l == 5 && splitpublicChat == 0 && privateChatMode < 2) {
-						if (i1 > 0 && i1 < 110) {
-							textDrawingArea.textLeft(0x800000, chatMessages[k], i1, 4);
-						}
-						j++;
-					}
-					if (l == 6 && splitpublicChat == 0 && privateChatMode < 2) {
-						if (i1 > 0 && i1 < 110) {
-							textDrawingArea.textLeft(0, "To " + s1 + ":", i1, 4);
-							textDrawingArea.textLeft(0x800000, chatMessages[k], i1, 12 + textDrawingArea.getTextWidth("To " + s1));
-						}
-						j++;
-					}
-					if (l == 8 && (tradeMode == 0 || tradeMode == 1 && isFriendOrSelf(s1))) {
-						if (i1 > 0 && i1 < 110) {
-							textDrawingArea.textLeft(0x7e3200, s1 + " " + chatMessages[k], i1, 4);
-						}
-						j++;
-					}
-				}
-			}
-
-			DrawingArea.defaultDrawingAreaSize();
-			chatScrollHeight = j * 14 + 7;
-			if (chatScrollHeight < 78) {
-				chatScrollHeight = 78;
-			}
-			drawScrollThumb(77, chatScrollHeight - chatScrollPosition - 77, 0, 463, chatScrollHeight);
-			String s;
-			if (myPlayer != null && myPlayer.name != null) {
-				s = myPlayer.name;
-			} else {
-				s = TextClass.fixName(myUsername);
-			}
-			textDrawingArea.textLeft(0, s + ":", 90, 4);
-			textDrawingArea.textLeft(255, inputString + "*", 90, 6 + textDrawingArea.getTextWidth(s + ": "));
-			DrawingArea.drawHorizontalLine(77, 0, 479, 0);
-		}
-		if (menuOpen && menuScreenArea == 2) {
-			drawMenu();
-		}
-		fullScreenBackground.drawGraphics(357, super.graphics, 17);
-		tabAreaBuffer.initDrawingArea();
-		Texture.lineOffsets = chatBoxAreaOffsets;
-	}
+public void drawChatArea() {
+        chatAreaRenderer.drawChatArea();
+}
 
 	public void init() {
 		try {
@@ -12013,9 +11882,10 @@ static final boolean constructMusic() {
 		cameraXOffsetSpeed = 2;
 		pathTileX = new int[4000];
 		pathTileY = new int[4000];
-		unusedSlotIndex = -1;
-		fileCRC = new CRC32();
-	}
+                unusedSlotIndex = -1;
+                fileCRC = new CRC32();
+                chatAreaRenderer = new ChatAreaRenderer(this);
+        }
 	public CRC32 fileCRC;
 	public static String server;
 	public int ignoreCount;
@@ -12426,10 +12296,11 @@ static final boolean constructMusic() {
 	public String loginMessage2;
 	public int mapEventX;
 	public int mapEventY;
-	public TextDrawingArea plainFont;
-	public TextDrawingArea boldFont;
-	public TextDrawingArea chatTextDrawingArea;
-	public int flameOffset;
+        public TextDrawingArea plainFont;
+        public TextDrawingArea boldFont;
+        public TextDrawingArea chatTextDrawingArea;
+        public final ChatAreaRenderer chatAreaRenderer;
+        public int flameOffset;
 	public int backDialogID;
 	public int cameraXOffset;
 	public int cameraXOffsetSpeed;

--- a/docs/Client/classes/ChatAreaRenderer.md
+++ b/docs/Client/classes/ChatAreaRenderer.md
@@ -1,0 +1,12 @@
+# ChatAreaRenderer
+
+Defined in [`2006Scape Client/src/main/java/core/ChatAreaRenderer.java`](../../2006Scape%20Client/src/main/java/core/ChatAreaRenderer.java).
+
+Renders the game's chat UI area. Extracted from [`Game`](Game.md) to reduce its size.
+
+```java
+final class ChatAreaRenderer {
+    ChatAreaRenderer(Game game)
+    void drawChatArea()
+}
+```

--- a/docs/Client/classes/Game.md
+++ b/docs/Client/classes/Game.md
@@ -172,3 +172,4 @@ public String getClipBoard()
 
 Utility helpers like `random` and `intToKOrMilLongName` now reside in
 [`GameUtils`](GameUtils.md).
+Chat area rendering code lives in [`ChatAreaRenderer`](ChatAreaRenderer.md).

--- a/docs/Client/index.md
+++ b/docs/Client/index.md
@@ -9,6 +9,7 @@
 - [BoundaryObject](Client/classes/BoundaryObject.md)
 - [CachePlaceholder](Client/classes/CachePlaceholder.md)
 - [CacheUtils](Client/classes/CacheUtils.md)
+- [ChatAreaRenderer](Client/classes/ChatAreaRenderer.md)
 - [Censor](Client/classes/Censor.md)
 - [Client](Client/classes/Client.md)
 - [ClientSettings](Client/classes/ClientSettings.md)


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
| ----------------------------------- | ------ |
| `mvn -B verify -o` passes (offline) | ❌ |
| `spotbugs:check` passes             | ❌ |
| ≥ 80 % coverage on touched lines    | ❌ |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Extracted chat area rendering code from the monolithic `Game` class into a new `ChatAreaRenderer` helper. This begins reducing `Game`'s size and isolates UI logic.

## 🗂️ Detailed Changes
- Added `ChatAreaRenderer` class with `drawChatArea` method.
- Delegated `Game.drawChatArea` to the new renderer and instantiated it in the constructor.
- Updated client documentation and class index to include the new class.

## 📊 Diff Stat
```text
.../src/main/java/core/ChatAreaRenderer.java       | 154 ++++++++++++++++++++
2006Scape Client/src/main/java/core/Game.java      | 157 ++-------------------
docs/Client/classes/ChatAreaRenderer.md            |  12 ++
docs/Client/classes/Game.md                        |   1 +
docs/Client/index.md                               |   1 +
5 files changed, 182 insertions(+), 143 deletions(-)
```

## 🧪 Integration-Test Log
```
find '2006Scape Client/src/main/java' -name '*.java' -print0 | xargs -0 javac && echo "compile success"
2006Scape Client/src/main/java/core/RSApplet.java:18: warning: [removal] Applet in java.applet has been deprecated and marked for removal
2006Scape Client/src/main/java/core/Game.java:2487: warning: [removal] AppletContext in java.applet has been deprecated and marked for removal
2006Scape Client/src/main/java/net/Signlink.java:395: warning: [removal] Applet in java.applet has been deprecated and marked for removal
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
3 warnings
compile success
```

## 📝 Rollback Plan
If this PR causes a failure on `main`, Section 9 of AGENTS.md applies and the agent will open an automatic revert PR using the command above.

------
https://chatgpt.com/codex/tasks/task_e_687ed6432160832b9b93844cd4462f14