### PR TITLE
[BOT] refactor: extract menu and music logic

### DIFF
--- a/2006Scape Client/src/main/java/core/engine/Game.java
+++ b/2006Scape Client/src/main/java/core/engine/Game.java
@@ -977,7 +977,7 @@ public class Game extends RSApplet {
     pendingSpawnManager.locatePendingSpawns();
   }
 
-  void drawLoadingText(int i, String s) {
+  public void drawLoadingText(int i, String s) {
     loadingPercent = i;
     errorMessage = s;
     resetImageProducers();
@@ -4050,197 +4050,11 @@ public class Game extends RSApplet {
   }
 
   public void buildAtNPCMenu(EntityDef entityDef, int i, int j, int k) {
-    if (menuActionRow >= 400) {
-      return;
-    }
-    if (entityDef.childrenIDs != null) {
-      entityDef = entityDef.transform();
-    }
-    if (entityDef == null) {
-      return;
-    }
-    if (!entityDef.clickable) {
-      return;
-    }
-    String s = entityDef.name;
-    if (entityDef.combatLevel != 0) {
-      s =
-          s
-              + combatDiffColor(myPlayer.combatLevel, entityDef.combatLevel)
-              + " (level-"
-              + entityDef.combatLevel
-              + ")";
-    }
-    if (itemSelected == 1) {
-      menuActionName[menuActionRow] = "Use " + selectedItemName + " with @yel@" + s;
-      menuActionID[menuActionRow] = 582;
-      menuActionCmd1[menuActionRow] = i;
-      menuActionCmd2[menuActionRow] = k;
-      menuActionCmd3[menuActionRow] = j;
-      menuActionRow++;
-      return;
-    }
-    if (spellSelected == 1) {
-      if ((spellUsableOn & 2) == 2) {
-        menuActionName[menuActionRow] = spellTooltip + " @yel@" + s;
-        menuActionID[menuActionRow] = 413;
-        menuActionCmd1[menuActionRow] = i;
-        menuActionCmd2[menuActionRow] = k;
-        menuActionCmd3[menuActionRow] = j;
-        menuActionRow++;
-      }
-    } else {
-      if (entityDef.actions != null) {
-        for (int l = 4; l >= 0; l--) {
-          if (entityDef.actions[l] != null && !entityDef.actions[l].equalsIgnoreCase("attack")) {
-            menuActionName[menuActionRow] = entityDef.actions[l] + " @yel@" + s;
-            if (l == 0) {
-              menuActionID[menuActionRow] = 20;
-            }
-            if (l == 1) {
-              menuActionID[menuActionRow] = 412;
-            }
-            if (l == 2) {
-              menuActionID[menuActionRow] = 225;
-            }
-            if (l == 3) {
-              menuActionID[menuActionRow] = 965;
-            }
-            if (l == 4) {
-              menuActionID[menuActionRow] = 478;
-            }
-            menuActionCmd1[menuActionRow] = i;
-            menuActionCmd2[menuActionRow] = k;
-            menuActionCmd3[menuActionRow] = j;
-            menuActionRow++;
-          }
-        }
-      }
-      if (entityDef.actions != null) {
-        for (int i1 = 4; i1 >= 0; i1--) {
-          if (entityDef.actions[i1] != null && entityDef.actions[i1].equalsIgnoreCase("attack")) {
-            char c = '\0';
-            if (entityDef.combatLevel > myPlayer.combatLevel) {
-              c = '\u07D0';
-            }
-            menuActionName[menuActionRow] = entityDef.actions[i1] + " @yel@" + s;
-            if (i1 == 0) {
-              menuActionID[menuActionRow] = 20 + c;
-            }
-            if (i1 == 1) {
-              menuActionID[menuActionRow] = 412 + c;
-            }
-            if (i1 == 2) {
-              menuActionID[menuActionRow] = 225 + c;
-            }
-            if (i1 == 3) {
-              menuActionID[menuActionRow] = 965 + c;
-            }
-            if (i1 == 4) {
-              menuActionID[menuActionRow] = 478 + c;
-            }
-            menuActionCmd1[menuActionRow] = i;
-            menuActionCmd2[menuActionRow] = k;
-            menuActionCmd3[menuActionRow] = j;
-            menuActionRow++;
-          }
-        }
-      }
-      menuActionName[menuActionRow] =
-          "Examine @yel@" + s + (showInfo ? " @gre@(@whi@" + entityDef.type + "@gre@)" : "");
-      menuActionID[menuActionRow] = 1025;
-      menuActionCmd1[menuActionRow] = i;
-      menuActionCmd2[menuActionRow] = k;
-      menuActionCmd3[menuActionRow] = j;
-      menuActionRow++;
-    }
+    menuManager.buildAtNPCMenu(entityDef, i, j, k);
   }
 
   public void buildAtPlayerMenu(int i, int j, Player player, int k) {
-    if (player == myPlayer) {
-      return;
-    }
-    if (menuActionRow >= 400) {
-      return;
-    }
-    String s;
-    if (player.skill == 0) {
-      if (player.combatLevel > 0) {
-        s =
-            player.name
-                + combatDiffColor(myPlayer.combatLevel, player.combatLevel)
-                + " (level-"
-                + player.combatLevel
-                + ")";
-      } else {
-        s = player.name + " @cya@(store)";
-      }
-    } else {
-      s = player.name + " (skill-" + player.skill + ")";
-    }
-    if (itemSelected == 1) {
-      menuActionName[menuActionRow] = "Use " + selectedItemName + " with @whi@" + s;
-      menuActionID[menuActionRow] = 491;
-      menuActionCmd1[menuActionRow] = j;
-      menuActionCmd2[menuActionRow] = i;
-      menuActionCmd3[menuActionRow] = k;
-      menuActionRow++;
-    } else if (spellSelected == 1) {
-      if ((spellUsableOn & 8) == 8) {
-        menuActionName[menuActionRow] = spellTooltip + " @whi@" + s;
-        menuActionID[menuActionRow] = 365;
-        menuActionCmd1[menuActionRow] = j;
-        menuActionCmd2[menuActionRow] = i;
-        menuActionCmd3[menuActionRow] = k;
-        menuActionRow++;
-      }
-    } else {
-      for (int l = 4; l >= 0; l--) {
-        if (atPlayerActions[l] != null) {
-          menuActionName[menuActionRow] = atPlayerActions[l] + " @whi@" + s;
-          char c = '\0';
-          if (atPlayerActions[l].equalsIgnoreCase("attack")) {
-            if (player.combatLevel > myPlayer.combatLevel) {
-              c = '\u07D0';
-            }
-            if (myPlayer.team != 0 && player.team != 0) {
-              if (myPlayer.team == player.team) {
-                c = '\u07D0';
-              } else {
-                c = '\0';
-              }
-            }
-          } else if (atPlayerArray[l]) {
-            c = '\u07D0';
-          }
-          if (l == 0) {
-            menuActionID[menuActionRow] = 561 + c;
-          }
-          if (l == 1) {
-            menuActionID[menuActionRow] = 779 + c;
-          }
-          if (l == 2) {
-            menuActionID[menuActionRow] = 27 + c;
-          }
-          if (l == 3) {
-            menuActionID[menuActionRow] = 577 + c;
-          }
-          if (l == 4) {
-            menuActionID[menuActionRow] = 729 + c;
-          }
-          menuActionCmd1[menuActionRow] = j;
-          menuActionCmd2[menuActionRow] = i;
-          menuActionCmd3[menuActionRow] = k;
-          menuActionRow++;
-        }
-      }
-    }
-    for (int i1 = 0; i1 < menuActionRow; i1++) {
-      if (menuActionID[i1] == 516) {
-        menuActionName[i1] = "Walk here @whi@" + s;
-        return;
-      }
-    }
+    menuManager.buildAtPlayerMenu(i, j, player, k);
   }
 
   public void locateSceneObject(PendingSpawn pendingSpawn) {
@@ -4248,105 +4062,9 @@ public class Game extends RSApplet {
   }
 
   public final void processSoundQueue() {
-    for (int index = 0; index < currentSound; index++) {
-      // if (soundDelay[index] <= 0) {
-      boolean flag1 = false;
-      try {
-        Stream stream = Sounds.createSoundStream(soundType[index], sound[index]);
-        new SoundPlayer(
-            (InputStream) new ByteArrayInputStream(stream.buffer, 0, stream.currentOffset),
-            soundVolume[index],
-            soundDelay[index]);
-        if (System.currentTimeMillis() + (long) (stream.currentOffset / 22)
-            > lastSoundUpdate + (long) (soundBufferOffset / 22)) {
-          soundBufferOffset = stream.currentOffset;
-          lastSoundUpdate = System.currentTimeMillis();
-        }
-      } catch (Exception exception) {
-        exception.printStackTrace();
-      }
-      if (!flag1 || soundDelay[index] == -5) {
-        currentSound--;
-        for (int j = index; j < currentSound; j++) {
-          sound[j] = sound[j + 1];
-          soundType[j] = soundType[j + 1];
-          soundDelay[j] = soundDelay[j + 1];
-          soundVolume[j] = soundVolume[j + 1];
-        }
-        index--;
-      } else {
-        soundDelay[index] = -5;
-      }
-      /*} else {
-      	soundDelay[index]--;
-      }*/
-    }
-    if (previousSong > 0) {
-      previousSong -= 20;
-      if (previousSong < 0) previousSong = 0;
-      if (previousSong == 0 && musicVolume != 0 && currentSong != -1) {
-        musicController.playSong(musicVolume, false, currentSong);
-      }
-    }
+    musicController.processSoundQueue();
   }
 
-  private void connectServer() {
-    int j = 5;
-    expectedCRCs[8] = 0;
-    int k = 0;
-    while (expectedCRCs[8] == 0) {
-      String s = "Unknown problem";
-      drawLoadingText(20, "Connecting to web server");
-      try {
-        DataInputStream datainputstream =
-            openJagGrabInputStream("crc" + (int) (Math.random() * 99999999D) + "-" + 317);
-        Stream crcStream = new Stream(new byte[40]);
-        datainputstream.readFully(crcStream.buffer, 0, 40);
-        datainputstream.close();
-        for (int i1 = 0; i1 < 9; i1++) expectedCRCs[i1] = crcStream.readDWord();
-
-        int j1 = crcStream.readDWord();
-        int k1 = 1234;
-        for (int l1 = 0; l1 < 9; l1++) k1 = (k1 << 1) + expectedCRCs[l1];
-
-        if (j1 != k1) {
-          s = "checksum problem";
-          expectedCRCs[8] = 0;
-        }
-      } catch (EOFException _ex) {
-        s = "EOF problem";
-        expectedCRCs[8] = 0;
-      } catch (IOException _ex) {
-        s = "FileServer Connection problem";
-        // Check if we already have cache files, if so then allow the client to load anyway
-        String cacheDir = Signlink.findcachedir();
-        expectedCRCs[8] = new File(cacheDir + "main_file_cache.dat").length() > 0 ? 1 : 0;
-      } catch (Exception _ex) {
-        s = "logic problem";
-        expectedCRCs[8] = 0;
-        if (!Signlink.reporterror) return;
-      }
-      if (expectedCRCs[8] == 0) {
-        k++;
-        for (int l = j; l > 0; l--) {
-          if (k >= 10) {
-            drawLoadingText(10, "Game updated - please reload page");
-            l = 10;
-          } else {
-            drawLoadingText(10, s + " - retry in " + l + " secs.");
-          }
-          try {
-            Thread.sleep(1000L);
-          } catch (Exception _ex) {
-          }
-        }
-
-        j *= 2;
-        if (j > 60) j = 60;
-        useJaggrab = !useJaggrab;
-      }
-    }
-  }
 
   void startUp() {
     drawLoadingText(20, "Starting up");
@@ -4371,7 +4089,7 @@ public class Game extends RSApplet {
       }
     }
     try {
-      connectServer();
+      loadingHandler.connectServer();
       titleStreamLoader = streamLoaderForName(1, "title screen", "title", expectedCRCs[1], 25);
       plainFont = new TextDrawingArea(false, "p11_full", titleStreamLoader);
       boldFont = new TextDrawingArea(false, "p12_full", titleStreamLoader);

--- a/2006Scape Client/src/main/java/core/handlers/LoadingHandler.java
+++ b/2006Scape Client/src/main/java/core/handlers/LoadingHandler.java
@@ -3,6 +3,11 @@ package core.handlers;
 import core.engine.Game;
 import core.managers.ObjectManager;
 import core.network.Signlink;
+import core.network.Stream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
 
 /** Handles game loading stages and map loading extracted from {@link Game}. */
 public final class LoadingHandler {
@@ -83,6 +88,64 @@ public final class LoadingHandler {
       game.constructMapRegion();
       game.stream.createFrame(121);
       return 0;
+    }
+  }
+
+  /** Retrieve update CRCs from the web server. */
+  public void connectServer() {
+    int j = 5;
+    game.expectedCRCs[8] = 0;
+    int k = 0;
+    while (game.expectedCRCs[8] == 0) {
+      String s = "Unknown problem";
+      game.drawLoadingText(20, "Connecting to web server");
+      try {
+        DataInputStream datainputstream =
+            game.openJagGrabInputStream("crc" + (int) (Math.random() * 99999999D) + "-" + 317);
+        Stream crcStream = new Stream(new byte[40]);
+        datainputstream.readFully(crcStream.buffer, 0, 40);
+        datainputstream.close();
+        for (int i1 = 0; i1 < 9; i1++) game.expectedCRCs[i1] = crcStream.readDWord();
+
+        int j1 = crcStream.readDWord();
+        int k1 = 1234;
+        for (int l1 = 0; l1 < 9; l1++) k1 = (k1 << 1) + game.expectedCRCs[l1];
+
+        if (j1 != k1) {
+          s = "checksum problem";
+          game.expectedCRCs[8] = 0;
+        }
+      } catch (EOFException _ex) {
+        s = "EOF problem";
+        game.expectedCRCs[8] = 0;
+      } catch (IOException _ex) {
+        s = "FileServer Connection problem";
+        String cacheDir = Signlink.findcachedir();
+        game.expectedCRCs[8] = new File(cacheDir + "main_file_cache.dat").length() > 0 ? 1 : 0;
+      } catch (Exception _ex) {
+        s = "logic problem";
+        game.expectedCRCs[8] = 0;
+        if (!Signlink.reporterror) return;
+      }
+      if (game.expectedCRCs[8] == 0) {
+        k++;
+        for (int l = j; l > 0; l--) {
+          if (k >= 10) {
+            game.drawLoadingText(10, "Game updated - please reload page");
+            l = 10;
+          } else {
+            game.drawLoadingText(10, s + " - retry in " + l + " secs.");
+          }
+          try {
+            Thread.sleep(1000L);
+          } catch (Exception _ex) {
+          }
+        }
+
+        j *= 2;
+        if (j > 60) j = 60;
+        game.useJaggrab = !game.useJaggrab;
+      }
     }
   }
 }

--- a/2006Scape Client/src/main/java/core/managers/GameMusicController.java
+++ b/2006Scape Client/src/main/java/core/managers/GameMusicController.java
@@ -2,6 +2,11 @@ package core.managers;
 
 import core.engine.Game;
 import core.network.Signlink;
+import audio.SoundPlayer;
+import audio.Sounds;
+import core.network.Stream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.File;
 import java.io.FileInputStream;
 
@@ -82,6 +87,50 @@ public final class GameMusicController {
       MusicSystem.queuedSongId = -1;
       MusicSystem.autoPlaySong = true;
       MusicSystem.nextSongDelay = -1;
+    }
+  }
+
+  /**
+   * Process the queued sound effects and background music.
+   *
+   * <p>Originally part of {@link core.engine.Game#processSoundQueue()}.
+   */
+  public void processSoundQueue() {
+    for (int index = 0; index < game.currentSound; index++) {
+      boolean flag1 = false;
+      try {
+        Stream stream = Sounds.createSoundStream(game.soundType[index], game.sound[index]);
+        new SoundPlayer(
+            (InputStream) new ByteArrayInputStream(stream.buffer, 0, stream.currentOffset),
+            game.soundVolume[index],
+            game.soundDelay[index]);
+        if (System.currentTimeMillis() + (long) (stream.currentOffset / 22)
+            > game.lastSoundUpdate + (long) (game.soundBufferOffset / 22)) {
+          game.soundBufferOffset = stream.currentOffset;
+          game.lastSoundUpdate = System.currentTimeMillis();
+        }
+      } catch (Exception exception) {
+        exception.printStackTrace();
+      }
+      if (!flag1 || game.soundDelay[index] == -5) {
+        game.currentSound--;
+        for (int j = index; j < game.currentSound; j++) {
+          game.sound[j] = game.sound[j + 1];
+          game.soundType[j] = game.soundType[j + 1];
+          game.soundDelay[j] = game.soundDelay[j + 1];
+          game.soundVolume[j] = game.soundVolume[j + 1];
+        }
+        index--;
+      } else {
+        game.soundDelay[index] = -5;
+      }
+    }
+    if (game.previousSong > 0) {
+      game.previousSong -= 20;
+      if (game.previousSong < 0) game.previousSong = 0;
+      if (game.previousSong == 0 && game.musicVolume != 0 && game.currentSong != -1) {
+        playSong(game.musicVolume, false, game.currentSong);
+      }
     }
   }
 

--- a/2006Scape Client/src/main/java/core/managers/MenuManager.java
+++ b/2006Scape Client/src/main/java/core/managers/MenuManager.java
@@ -3,6 +3,8 @@ package core.managers;
 import core.engine.Game;
 import render.core.DrawingArea;
 import ui.RSInterface;
+import game.definitions.EntityDef;
+import game.entities.Player;
 
 /** Handles menu interactions extracted from {@link Game}. */
 public final class MenuManager {
@@ -275,6 +277,199 @@ public final class MenuManager {
       game.menuOffsetY = j2;
       game.menuWidth = i;
       game.menuHeight = 15 * game.menuActionRow + 22;
+    }
+  }
+
+  /** Build context menu entries for interacting with an NPC. */
+  public void buildAtNPCMenu(EntityDef entityDef, int i, int j, int k) {
+    if (game.menuActionRow >= 400) {
+      return;
+    }
+    if (entityDef.childrenIDs != null) {
+      entityDef = entityDef.transform();
+    }
+    if (entityDef == null || !entityDef.clickable) {
+      return;
+    }
+    String s = entityDef.name;
+    if (entityDef.combatLevel != 0) {
+      s =
+          s
+              + game.combatDiffColor(game.myPlayer.combatLevel, entityDef.combatLevel)
+              + " (level-"
+              + entityDef.combatLevel
+              + ")";
+    }
+    if (game.itemSelected == 1) {
+      game.menuActionName[game.menuActionRow] = "Use " + game.selectedItemName + " with @yel@" + s;
+      game.menuActionID[game.menuActionRow] = 582;
+      game.menuActionCmd1[game.menuActionRow] = i;
+      game.menuActionCmd2[game.menuActionRow] = k;
+      game.menuActionCmd3[game.menuActionRow] = j;
+      game.menuActionRow++;
+      return;
+    }
+    if (game.spellSelected == 1) {
+      if ((game.spellUsableOn & 2) == 2) {
+        game.menuActionName[game.menuActionRow] = game.spellTooltip + " @yel@" + s;
+        game.menuActionID[game.menuActionRow] = 413;
+        game.menuActionCmd1[game.menuActionRow] = i;
+        game.menuActionCmd2[game.menuActionRow] = k;
+        game.menuActionCmd3[game.menuActionRow] = j;
+        game.menuActionRow++;
+      }
+    } else {
+      if (entityDef.actions != null) {
+        for (int l = 4; l >= 0; l--) {
+          if (entityDef.actions[l] != null && !entityDef.actions[l].equalsIgnoreCase("attack")) {
+            game.menuActionName[game.menuActionRow] = entityDef.actions[l] + " @yel@" + s;
+            if (l == 0) {
+              game.menuActionID[game.menuActionRow] = 20;
+            }
+            if (l == 1) {
+              game.menuActionID[game.menuActionRow] = 412;
+            }
+            if (l == 2) {
+              game.menuActionID[game.menuActionRow] = 225;
+            }
+            if (l == 3) {
+              game.menuActionID[game.menuActionRow] = 965;
+            }
+            if (l == 4) {
+              game.menuActionID[game.menuActionRow] = 478;
+            }
+            game.menuActionCmd1[game.menuActionRow] = i;
+            game.menuActionCmd2[game.menuActionRow] = k;
+            game.menuActionCmd3[game.menuActionRow] = j;
+            game.menuActionRow++;
+          }
+        }
+      }
+      if (entityDef.actions != null) {
+        for (int i1 = 4; i1 >= 0; i1--) {
+          if (entityDef.actions[i1] != null && entityDef.actions[i1].equalsIgnoreCase("attack")) {
+            char c = '\0';
+            if (entityDef.combatLevel > game.myPlayer.combatLevel) {
+              c = '\u07D0';
+            }
+            game.menuActionName[game.menuActionRow] = entityDef.actions[i1] + " @yel@" + s;
+            if (i1 == 0) {
+              game.menuActionID[game.menuActionRow] = 20 + c;
+            }
+            if (i1 == 1) {
+              game.menuActionID[game.menuActionRow] = 412 + c;
+            }
+            if (i1 == 2) {
+              game.menuActionID[game.menuActionRow] = 225 + c;
+            }
+            if (i1 == 3) {
+              game.menuActionID[game.menuActionRow] = 965 + c;
+            }
+            if (i1 == 4) {
+              game.menuActionID[game.menuActionRow] = 478 + c;
+            }
+            game.menuActionCmd1[game.menuActionRow] = i;
+            game.menuActionCmd2[game.menuActionRow] = k;
+            game.menuActionCmd3[game.menuActionRow] = j;
+            game.menuActionRow++;
+          }
+        }
+      }
+      game.menuActionName[game.menuActionRow] =
+          "Examine @yel@" + s + (game.showInfo ? " @gre@(@whi@" + entityDef.type + "@gre@)" : "");
+      game.menuActionID[game.menuActionRow] = 1025;
+      game.menuActionCmd1[game.menuActionRow] = i;
+      game.menuActionCmd2[game.menuActionRow] = k;
+      game.menuActionCmd3[game.menuActionRow] = j;
+      game.menuActionRow++;
+    }
+  }
+
+  /** Build context menu entries for interacting with another player. */
+  public void buildAtPlayerMenu(int i, int j, Player player, int k) {
+    if (player == game.myPlayer) {
+      return;
+    }
+    if (game.menuActionRow >= 400) {
+      return;
+    }
+    String s;
+    if (player.skill == 0) {
+      if (player.combatLevel > 0) {
+        s =
+            player.name
+                + game.combatDiffColor(game.myPlayer.combatLevel, player.combatLevel)
+                + " (level-"
+                + player.combatLevel
+                + ")";
+      } else {
+        s = player.name + " @cya@(store)";
+      }
+    } else {
+      s = player.name + " (skill-" + player.skill + ")";
+    }
+    if (game.itemSelected == 1) {
+      game.menuActionName[game.menuActionRow] = "Use " + game.selectedItemName + " with @whi@" + s;
+      game.menuActionID[game.menuActionRow] = 491;
+      game.menuActionCmd1[game.menuActionRow] = j;
+      game.menuActionCmd2[game.menuActionRow] = i;
+      game.menuActionCmd3[game.menuActionRow] = k;
+      game.menuActionRow++;
+    } else if (game.spellSelected == 1) {
+      if ((game.spellUsableOn & 8) == 8) {
+        game.menuActionName[game.menuActionRow] = game.spellTooltip + " @whi@" + s;
+        game.menuActionID[game.menuActionRow] = 365;
+        game.menuActionCmd1[game.menuActionRow] = j;
+        game.menuActionCmd2[game.menuActionRow] = i;
+        game.menuActionCmd3[game.menuActionRow] = k;
+        game.menuActionRow++;
+      }
+    } else {
+      for (int l = 4; l >= 0; l--) {
+        if (game.atPlayerActions[l] != null) {
+          game.menuActionName[game.menuActionRow] = game.atPlayerActions[l] + " @whi@" + s;
+          char c = '\0';
+          if (game.atPlayerActions[l].equalsIgnoreCase("attack")) {
+            if (player.combatLevel > game.myPlayer.combatLevel) {
+              c = '\u07D0';
+            }
+            if (game.myPlayer.team != 0 && player.team != 0) {
+              if (game.myPlayer.team == player.team) {
+                c = '\u07D0';
+              } else {
+                c = '\0';
+              }
+            }
+          } else if (game.atPlayerArray[l]) {
+            c = '\u07D0';
+          }
+          if (l == 0) {
+            game.menuActionID[game.menuActionRow] = 561 + c;
+          }
+          if (l == 1) {
+            game.menuActionID[game.menuActionRow] = 779 + c;
+          }
+          if (l == 2) {
+            game.menuActionID[game.menuActionRow] = 27 + c;
+          }
+          if (l == 3) {
+            game.menuActionID[game.menuActionRow] = 577 + c;
+          }
+          if (l == 4) {
+            game.menuActionID[game.menuActionRow] = 729 + c;
+          }
+          game.menuActionCmd1[game.menuActionRow] = j;
+          game.menuActionCmd2[game.menuActionRow] = i;
+          game.menuActionCmd3[game.menuActionRow] = k;
+          game.menuActionRow++;
+        }
+      }
+    }
+    for (int i1 = 0; i1 < game.menuActionRow; i1++) {
+      if (game.menuActionID[i1] == 516) {
+        game.menuActionName[i1] = "Walk here @whi@" + s;
+        return;
+      }
     }
   }
 }

--- a/docs/Client/classes/Game.md
+++ b/docs/Client/classes/Game.md
@@ -89,10 +89,10 @@ public int blendColors(int i, int j, int k)
 public void login(String s, String s1, boolean flag)
 public boolean doWalkTo(int i, int j, int k, int i1, int j1, int k1, int l1, int i2, int j2, boolean flag, int k2)
 public void processNpcUpdateMasks(Stream stream)
-public void buildAtNPCMenu(EntityDef entityDef, int i, int j, int k)
-public void buildAtPlayerMenu(int i, int j, Player player, int k)
+public void buildAtNPCMenu(EntityDef entityDef, int i, int j, int k) -> MenuManager.buildAtNPCMenu
+public void buildAtPlayerMenu(int i, int j, Player player, int k) -> MenuManager.buildAtPlayerMenu
 public void locateSceneObject(PendingSpawn pendingSpawn) -> PendingSpawnManager.locateSceneObject
-public final void processSoundQueue()
+public final void processSoundQueue() -> GameMusicController.processSoundQueue
 public void addLocalPlayers(Stream stream, int i)
 public void processMainScreenClick()
 public String interfaceIntToString(int j)

--- a/docs/Client/classes/GameMusicController.md
+++ b/docs/Client/classes/GameMusicController.md
@@ -11,5 +11,6 @@ public final class GameMusicController {
     byte[] getMusic(int index)
     void queueSong(int delay, int volume, boolean bool, int music)
     void playSong(int volume, boolean bool, int music)
+    void processSoundQueue()
 }
 ```

--- a/docs/Client/classes/LoadingHandler.md
+++ b/docs/Client/classes/LoadingHandler.md
@@ -1,0 +1,14 @@
+# LoadingHandler
+
+Defined in [`2006Scape Client/src/main/java/core/handlers/LoadingHandler.java`](../../2006Scape%20Client/src/main/java/core/handlers/LoadingHandler.java).
+
+Handles client loading stages and CRC connection logic extracted from [`Game`](Game.md).
+
+```java
+final class LoadingHandler {
+    LoadingHandler(Game game)
+    void loadingStages()
+    int checkMapLoadStatus()
+    void connectServer()
+}
+```

--- a/docs/Client/classes/MenuManager.md
+++ b/docs/Client/classes/MenuManager.md
@@ -12,5 +12,7 @@ final class MenuManager {
     boolean processMenuClick()
     void drawMenu()
     void determineMenuSize()
+    void buildAtNPCMenu(EntityDef def, int id, int x, int y)
+    void buildAtPlayerMenu(int x, int id, Player player, int y)
 }
 ```

--- a/docs/Client/index.md
+++ b/docs/Client/index.md
@@ -48,6 +48,7 @@
 - [ItemDef](Client/classes/ItemDef.md)
 - [ItemPile](Client/classes/ItemPile.md)
 - [LocalGame](Client/classes/LocalGame.md)
+- [LoadingHandler](Client/classes/LoadingHandler.md)
 - [LoginScreen](Client/classes/LoginScreen.md)
 - [LoginManager](Client/classes/LoginManager.md)
 - [MRUCache](Client/classes/MRUCache.md)


### PR DESCRIPTION
## Summary
- move NPC and player menu construction to `MenuManager`
- move sound queue processing to `GameMusicController`
- expose `drawLoadingText` for use by `LoadingHandler`
- delegate startup CRC download to `LoadingHandler`
- document new methods and handler

## Testing
- `git ls-files '2006Scape Client/src/main/java/*.java' -z | xargs -0 javac`

------
https://chatgpt.com/codex/tasks/task_e_688366871890832bb5a834eeb1b5b143