### PR TITLE
[BOT] refactor(Game): move interface helpers

### DIFF
--- a/2006Scape Client/src/main/java/core/engine/Game.java
+++ b/2006Scape Client/src/main/java/core/engine/Game.java
@@ -591,19 +591,7 @@ public class Game extends RSApplet {
   }
 
   public void resetInterfaceAnimation(int i) {
-    RSInterface parentInterface = RSInterface.interfaceCache[i];
-    if (parentInterface == null || parentInterface.children == null) return;
-    for (int element : parentInterface.children) {
-      if (element == -1) {
-        break;
-      }
-      RSInterface childWidget = RSInterface.interfaceCache[element];
-      if (childWidget.type == 1) {
-        resetInterfaceAnimation(childWidget.id);
-      }
-      childWidget.animationFrame = 0;
-      childWidget.animationCycle = 0;
-    }
+    interfaceInputHandler.resetInterfaceAnimation(i);
   }
 
   public void drawHeadIcon() {
@@ -1018,74 +1006,12 @@ public class Game extends RSApplet {
 
   public void handleScrollbarInput(
       int i, int j, int k, int l, RSInterface scrollInterface, int i1, boolean flag, int j1) {
-    int scrollPadding;
-    if (scrollBarDragging) {
-      scrollPadding = 32;
-    } else {
-      scrollPadding = 0;
-    }
-    scrollBarDragging = false;
-    if (k >= i && k < i + 16 && l >= i1 && l < i1 + 16) {
-      scrollInterface.scrollPosition -= clickCycle * 4;
-      if (flag) {
-        needDrawTabArea = true;
-      }
-    } else if (k >= i && k < i + 16 && l >= i1 + j - 16 && l < i1 + j) {
-      scrollInterface.scrollPosition += clickCycle * 4;
-      if (flag) {
-        needDrawTabArea = true;
-      }
-    } else if (k >= i - scrollPadding
-        && k < i + 16 + scrollPadding
-        && l >= i1 + 16
-        && l < i1 + j - 16
-        && clickCycle > 0) {
-      int l1 = (j - 32) * j / j1;
-      if (l1 < 8) {
-        l1 = 8;
-      }
-      int i2 = l - i1 - 16 - l1 / 2;
-      int j2 = j - 32 - l1;
-      scrollInterface.scrollPosition = (j1 - j) * i2 / j2;
-      if (flag) {
-        needDrawTabArea = true;
-      }
-      scrollBarDragging = true;
-    }
+    interfaceInputHandler.handleScrollbarInput(
+        i, j, k, l, scrollInterface, i1, flag, j1);
   }
 
   public boolean walkToObject(int i, int j, int k) {
-    int i1 = i >> 14 & 0x7fff;
-    int j1 = worldController.getObjectConfig(plane, k, j, i);
-    if (j1 == -1) {
-      return false;
-    }
-    int k1 = j1 & 0x1f;
-    int l1 = j1 >> 6 & 3;
-    if (k1 == 10 || k1 == 11 || k1 == 22) {
-      ObjectDef objectDef = ObjectDef.forID(i1);
-      int i2;
-      int j2;
-      if (l1 == 0 || l1 == 2) {
-        i2 = objectDef.sizeX;
-        j2 = objectDef.sizeY;
-      } else {
-        i2 = objectDef.sizeY;
-        j2 = objectDef.sizeX;
-      }
-      int k2 = objectDef.defaultOrientation;
-      if (l1 != 0) {
-        k2 = (k2 << l1 & 0xf) + (k2 >> 4 - l1);
-      }
-      doWalkTo(2, 0, j2, 0, myPlayer.smallY[0], i2, k2, j, myPlayer.smallX[0], false, k);
-    } else {
-      doWalkTo(2, l1, 0, k1 + 1, myPlayer.smallY[0], 0, 0, j, myPlayer.smallX[0], false, k);
-    }
-    crossX = super.saveClickX;
-    crossY = super.saveClickY;
-    crossType = 2;
-    crossIndex = 0;
-    return true;
+    return pathfinder.walkToObject(i, j, k);
   }
 
   public StreamLoader streamLoaderForName(int i, String s, String s1, int j, int k) {
@@ -8388,42 +8314,11 @@ public class Game extends RSApplet {
   }
 
   public void openInterface(int interfaceID) {
-    resetInterfaceAnimation(interfaceID);
-    if (invOverlayInterfaceID != -1) {
-      invOverlayInterfaceID = -1;
-      needDrawTabArea = true;
-      tabAreaAltered = true;
-    }
-    if (backDialogID != -1) {
-      backDialogID = -1;
-      inputTaken = true;
-    }
-    if (inputDialogState != 0) {
-      inputDialogState = 0;
-      inputTaken = true;
-    }
-    if (interfaceID == 15244) {
-      if (ClientSettings.SNOW_OVERLAY_FORCE_ENABLED
-          || (ClientSettings.SNOW_OVERLAY_ENABLED
-              && FloorOverlay.getTodaysDate().contains(ClientSettings.SNOW_MONTH))) {
-        openInterfaceID = 15819;
-      } else {
-        openInterfaceID = 15801;
-      }
-      fullScreenInterfaceId = 15244;
-    } else {
-      openInterfaceID = interfaceID;
-    }
-    actionPending = false;
+    interfaceInputHandler.openInterface(interfaceID);
   }
 
   public void openSideInterface(int tab, int interfaceID) {
-    if (interfaceID == 0x00ffff) {
-      interfaceID = -1;
-    }
-    tabInterfaceIDs[tab] = interfaceID;
-    needDrawTabArea = true;
-    tabAreaAltered = true;
+    interfaceInputHandler.openSideInterface(tab, interfaceID);
   }
 
   public final void mouseWheelMoved(MouseWheelEvent e) {

--- a/2006Scape Client/src/main/java/core/handlers/InterfaceInputHandler.java
+++ b/2006Scape Client/src/main/java/core/handlers/InterfaceInputHandler.java
@@ -1,6 +1,8 @@
 package core.handlers;
 
 import core.engine.Game;
+import core.engine.ClientSettings;
+import render.tiles.FloorOverlay;
 import ui.RSInterface;
 import ui.TextClass;
 import util.configuration.IDK;
@@ -118,5 +120,105 @@ public final class InterfaceInputHandler {
       }
     }
     return false;
+  }
+
+  public void handleScrollbarInput(
+      int i,
+      int j,
+      int k,
+      int l,
+      RSInterface scrollInterface,
+      int i1,
+      boolean flag,
+      int j1) {
+    int scrollPadding;
+    if (game.scrollBarDragging) {
+      scrollPadding = 32;
+    } else {
+      scrollPadding = 0;
+    }
+    game.scrollBarDragging = false;
+    if (k >= i && k < i + 16 && l >= i1 && l < i1 + 16) {
+      scrollInterface.scrollPosition -= game.clickCycle * 4;
+      if (flag) {
+        game.needDrawTabArea = true;
+      }
+    } else if (k >= i && k < i + 16 && l >= i1 + j - 16 && l < i1 + j) {
+      scrollInterface.scrollPosition += game.clickCycle * 4;
+      if (flag) {
+        game.needDrawTabArea = true;
+      }
+    } else if (k >= i - scrollPadding
+        && k < i + 16 + scrollPadding
+        && l >= i1 + 16
+        && l < i1 + j - 16
+        && game.clickCycle > 0) {
+      int l1 = (j - 32) * j / j1;
+      if (l1 < 8) {
+        l1 = 8;
+      }
+      int i2 = l - i1 - 16 - l1 / 2;
+      int j2 = j - 32 - l1;
+      scrollInterface.scrollPosition = (j1 - j) * i2 / j2;
+      if (flag) {
+        game.needDrawTabArea = true;
+      }
+      game.scrollBarDragging = true;
+    }
+  }
+
+  public void resetInterfaceAnimation(int i) {
+    RSInterface parentInterface = RSInterface.interfaceCache[i];
+    if (parentInterface == null || parentInterface.children == null) return;
+    for (int element : parentInterface.children) {
+      if (element == -1) {
+        break;
+      }
+      RSInterface childWidget = RSInterface.interfaceCache[element];
+      if (childWidget.type == 1) {
+        resetInterfaceAnimation(childWidget.id);
+      }
+      childWidget.animationFrame = 0;
+      childWidget.animationCycle = 0;
+    }
+  }
+
+  public void openInterface(int interfaceID) {
+    resetInterfaceAnimation(interfaceID);
+    if (game.invOverlayInterfaceID != -1) {
+      game.invOverlayInterfaceID = -1;
+      game.needDrawTabArea = true;
+      game.tabAreaAltered = true;
+    }
+    if (game.backDialogID != -1) {
+      game.backDialogID = -1;
+      game.inputTaken = true;
+    }
+    if (game.inputDialogState != 0) {
+      game.inputDialogState = 0;
+      game.inputTaken = true;
+    }
+    if (interfaceID == 15244) {
+      if (ClientSettings.SNOW_OVERLAY_FORCE_ENABLED
+          || (ClientSettings.SNOW_OVERLAY_ENABLED
+              && FloorOverlay.getTodaysDate().contains(ClientSettings.SNOW_MONTH))) {
+        game.openInterfaceID = 15819;
+      } else {
+        game.openInterfaceID = 15801;
+      }
+      game.fullScreenInterfaceId = 15244;
+    } else {
+      game.openInterfaceID = interfaceID;
+    }
+    game.actionPending = false;
+  }
+
+  public void openSideInterface(int tab, int interfaceID) {
+    if (interfaceID == 0x00ffff) {
+      interfaceID = -1;
+    }
+    game.tabInterfaceIDs[tab] = interfaceID;
+    game.needDrawTabArea = true;
+    game.tabAreaAltered = true;
   }
 }

--- a/2006Scape Client/src/main/java/core/world/Pathfinder.java
+++ b/2006Scape Client/src/main/java/core/world/Pathfinder.java
@@ -1,6 +1,7 @@
 package core.world;
 
 import core.engine.Game;
+import game.definitions.ObjectDef;
 
 /** Performs A* style walking path calculations extracted from {@link Game}. */
 public final class Pathfinder {
@@ -227,5 +228,39 @@ public final class Pathfinder {
       return true;
     }
     return i != 1;
+  }
+
+  public boolean walkToObject(int i, int j, int k) {
+    int i1 = i >> 14 & 0x7fff;
+    int j1 = game.worldController.getObjectConfig(game.plane, k, j, i);
+    if (j1 == -1) {
+      return false;
+    }
+    int k1 = j1 & 0x1f;
+    int l1 = j1 >> 6 & 3;
+    if (k1 == 10 || k1 == 11 || k1 == 22) {
+      ObjectDef objectDef = ObjectDef.forID(i1);
+      int i2;
+      int j2;
+      if (l1 == 0 || l1 == 2) {
+        i2 = objectDef.sizeX;
+        j2 = objectDef.sizeY;
+      } else {
+        i2 = objectDef.sizeY;
+        j2 = objectDef.sizeX;
+      }
+      int k2 = objectDef.defaultOrientation;
+      if (l1 != 0) {
+        k2 = (k2 << l1 & 0xf) + (k2 >> 4 - l1);
+      }
+      doWalkTo(2, 0, j2, 0, game.myPlayer.smallY[0], i2, k2, j, game.myPlayer.smallX[0], false, k);
+    } else {
+      doWalkTo(2, l1, 0, k1 + 1, game.myPlayer.smallY[0], 0, 0, j, game.myPlayer.smallX[0], false, k);
+    }
+    game.crossX = game.saveClickX;
+    game.crossY = game.saveClickY;
+    game.crossType = 2;
+    game.crossIndex = 0;
+    return true;
   }
 }

--- a/docs/Client/classes/Game.md
+++ b/docs/Client/classes/Game.md
@@ -56,12 +56,12 @@ public void drawLogo()
 public void processOnDemandQueue()
 public void calcFlamesPosition()
 public boolean saveWave(byte abyte0[], int i)
-public void resetInterfaceAnimation(int i)
+public void resetInterfaceAnimation(int i) -> InterfaceInputHandler.resetInterfaceAnimation
 public void drawHeadIcon()
 public void mainGameProcessor()
 public void locatePendingSpawns() -> PendingSpawnManager.locatePendingSpawns
-public void handleScrollbarInput(int i, int j, int k, int l, RSInterface scrollInterface, int i1, boolean flag, int j1)
-public boolean walkToObject(int i, int j, int k)
+public void handleScrollbarInput(int i, int j, int k, int l, RSInterface scrollInterface, int i1, boolean flag, int j1) -> InterfaceInputHandler.handleScrollbarInput
+public boolean walkToObject(int i, int j, int k) -> Pathfinder.walkToObject
 public StreamLoader streamLoaderForName(int i, String s, String s1, int j, int k)
 public void dropClient()
 public void drawTextOnScreen(String s, String s1)
@@ -160,8 +160,8 @@ public void keyPressed(KeyEvent keyevent) -> InputHandler.handleKeyPressed
 public long calculateTotalExp() -> PlayerStatsCalculator.calculateTotalExp
 public int calculateTotalLevels() -> PlayerStatsCalculator.calculateTotalLevels
 public void definitionSearch(String name, int type) -> DefinitionSearcher.search
-public void openInterface(int interfaceID)
-public void openSideInterface(int tab, int interfaceID)
+public void openInterface(int interfaceID) -> InterfaceInputHandler.openInterface
+public void openSideInterface(int tab, int interfaceID) -> InterfaceInputHandler.openSideInterface
 public final void mouseWheelMoved(MouseWheelEvent e) -> InputHandler.handleMouseWheelMoved
 ```
 

--- a/docs/Client/classes/InterfaceInputHandler.md
+++ b/docs/Client/classes/InterfaceInputHandler.md
@@ -1,0 +1,18 @@
+# InterfaceInputHandler
+
+Defined in [`2006Scape Client/src/main/java/core/handlers/InterfaceInputHandler.java`](../../2006Scape%20Client/src/main/java/core/handlers/InterfaceInputHandler.java).
+
+Handles interface-related input tasks extracted from [`Game`](Game.md).
+
+```java
+final class InterfaceInputHandler {
+    InterfaceInputHandler(Game game)
+    boolean promptUserForInput(RSInterface widget)
+    void handleScrollbarInput(int i, int j, int k, int l,
+                              RSInterface scrollInterface,
+                              int i1, boolean flag, int j1)
+    void resetInterfaceAnimation(int i)
+    void openInterface(int interfaceID)
+    void openSideInterface(int tab, int interfaceID)
+}
+```

--- a/docs/Client/classes/Pathfinder.md
+++ b/docs/Client/classes/Pathfinder.md
@@ -9,5 +9,6 @@ final class Pathfinder {
     Pathfinder(Game game)
     boolean doWalkTo(int i, int j, int k, int i1, int j1, int k1,
                      int l1, int i2, int j2, boolean flag, int k2)
+    boolean walkToObject(int i, int j, int k)
 }
 ```

--- a/docs/Client/index.md
+++ b/docs/Client/index.md
@@ -41,6 +41,7 @@
 - [IDK](Client/classes/IDK.md)
 - [IgnoreManager](Client/classes/IgnoreManager.md)
 - [InputHandler](Client/classes/InputHandler.md)
+- [InterfaceInputHandler](Client/classes/InterfaceInputHandler.md)
 - [InterfaceMenuBuilder](Client/classes/InterfaceMenuBuilder.md)
 - [ISAACRandomGen](Client/classes/ISAACRandomGen.md)
 - [Instrument](Client/classes/Instrument.md)


### PR DESCRIPTION
# 🤖 RuneBot Pull Request

## ✅ Pre-flight Checklist

| Item                                | Status |
|-------------------------------------| ------ |
| `mvn -B verify -o` passes (offline) |        |
| `spotbugs:check` passes             |        |
| ≥ 80 % coverage on touched lines    |        |
| Net Δ lines < 5 000                 | ✅ |
| ≤ 10 files modified                 | ✅ |
| Branch rebased onto latest `main`   | ✅ |
| PR labeled `bot`                    | ✅ |
| No new external dependencies        | ✅ |

## 🔍 What & Why
Moves several interface management methods out of `Game` into existing helper classes. This continues reducing the size of `Game` while keeping behaviour intact.

## 🗂️ Detailed Changes
- Added `handleScrollbarInput`, `resetInterfaceAnimation`, `openInterface`, and `openSideInterface` to `InterfaceInputHandler`
- Moved `walkToObject` logic into `Pathfinder`
- Updated `Game` methods to delegate to these helpers
- Documented `InterfaceInputHandler` and updated docs for `Game` and `Pathfinder`

## 📊 Diff Stat
```text
.../src/main/java/core/engine/Game.java            | 141 +++------------------
.../java/core/handlers/InterfaceInputHandler.java  | 116 ++++++++++++++++-
.../src/main/java/core/world/Pathfinder.java       |  47 ++++++-
docs/Client/classes/Game.md                        |  10 +-
docs/Client/classes/InterfaceInputHandler.md       |  18 +++
docs/Client/classes/Pathfinder.md                  |   1 +
docs/Client/index.md                               |   1 +
7 files changed, 193 insertions(+), 141 deletions(-)
```

## 🧪 Integration-Test Log
Compilation succeeded locally using `javac`.

## 📝 Rollback Plan
If this PR causes a failure on `main`, revert using `git revert -m 1 <commit-sha>`.

------
https://chatgpt.com/codex/tasks/task_e_68836a9e12bc832ba8deae2c9aca8cd2